### PR TITLE
Add github-release binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Available targets:
   chamber                             Install Chamber to manage secrets with SSM+KMS
   fetch                               Install fetch to easily download files, folders, and release assets from a specific git commit, branch, or tag
   github-commenter                    Install github-commenter
+  github-release                      Install github-release to create and edit releases on Github (and upload artifacts)
   gomplate                            Install gomplate
   goofys                              Install goofys
   helm                                Install helm

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -6,6 +6,7 @@ Available targets:
   chamber                             Install Chamber to manage secrets with SSM+KMS
   fetch                               Install fetch to easily download files, folders, and release assets from a specific git commit, branch, or tag
   github-commenter                    Install github-commenter
+  github-release                      Install github-release to create and edit releases on Github (and upload artifacts)
   gomplate                            Install gomplate
   goofys                              Install goofys
   helm                                Install helm

--- a/install/Makefile
+++ b/install/Makefile
@@ -48,6 +48,15 @@ export GITHUB_COMMENTER_VERSION ?= 0.1.0
 github-commenter:
 	$(call github_download_binary_release,cloudposse,$(GITHUB_COMMENTER_VERSION),$@_$(OS)_$(ARCH))
 
+export GITHUB_RELEASE_VERSION ?= 0.7.2
+## Install github-release to create and edit releases on Github (and upload artifacts)
+github-release:
+	mkdir -p $(TMP)/$@
+	$(CURL) -o - https://github.com/aktau/$@/releases/download/v$(GITHUB_RELEASE_VERSION)/$(OS)-$(ARCH)-$@.tar.bz2 | tar -C $(TMP)/$@ -zx bin/$(OS)/$(ARCH)/$@
+	mv $(TMP)/$@/bin/$(OS)/$(ARCH)/$@ $(INSTALL_PATH)/$@
+	rm -rf $(TMP)/$@
+	chmod +x $(INSTALL_PATH)/$@
+
 export GOMPLATE_VERSION ?= 2.6.0
 ## Install gomplate
 gomplate:


### PR DESCRIPTION
## what
* Add `github-release` 

## why
* so we can easily attach binaries to releases from codefresh in the build-harness

