### PR TITLE
[figurine] Add target for installing new package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
+
+
+
+
+
 ## Usage
 
 See all available packages:
@@ -112,6 +117,7 @@ Available targets:
   cfssl                               Install cfssl - Cloudflare's PKI and TLS toolkit 
   chamber                             Install Chamber to manage secrets with SSM+KMS
   fetch                               Install fetch to easily download files, folders, and release assets from a specific git commit, branch, or tag
+  figurine                            Install figurine foir printing your name in style
   github-commenter                    Install github-commenter
   github-release                      Install github-release to create and edit releases on Github (and upload artifacts)
   gomplate                            Install gomplate
@@ -154,11 +160,11 @@ Check out these related projects.
 
 File a GitHub [issue](https://github.com/cloudposse/packages/issues), send us an [email][email] or join our [Slack Community][slack].
 
-## Commerical Support
+## Commercial Support
 
 Work directly with our team of DevOps experts via email, slack, and video conferencing. 
 
-We provide *commercial support* for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a fulltime engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)](mailto:hello@cloudposse.com)
 
@@ -168,7 +174,7 @@ We provide *commercial support* for all of our [Open Source][github] projects. A
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll develop original modules to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
 
 
 ## Community Forum
@@ -226,6 +232,13 @@ See [LICENSE](LICENSE) for full details.
     under the License.
 
 
+
+
+
+
+
+
+
 ## Trademarks
 
 All other trademarks referenced herein are the property of their respective owners.
@@ -245,6 +258,7 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
   [docs]: https://docs.cloudposse.com/
   [website]: https://cloudposse.com/
   [github]: https://github.com/cloudposse/
+  [commercial_support]: https://github.com/orgs/cloudposse/projects
   [jobs]: https://cloudposse.com/jobs/
   [hire]: https://cloudposse.com/contact/
   [slack]: https://slack.cloudposse.com/

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Available targets:
   chamber                             Install Chamber to manage secrets with SSM+KMS
   cloudflared                         Install cloudflared which offers an easy way to expose web servers securely to the internet(Argo Tunnel)
   fetch                               Install fetch to easily download files, folders, and release assets from a specific git commit, branch, or tag
-  figurine                            Install figurine foir printing your name in style
+  figurine                            Install figurine to generate fancy colorized ASCII banners
   ghr                                 Install ghr to easily upload multiple artifacts to GitHub Release
   ghr-darwin                          Install ghr to easily upload multiple artifacts to GitHub Release (Darwin)
   ghr-linux                           Install ghr to easily upload multiple artifacts to GitHub Release (Linux)

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -7,6 +7,7 @@ Available targets:
   cfssl                               Install cfssl - Cloudflare's PKI and TLS toolkit 
   chamber                             Install Chamber to manage secrets with SSM+KMS
   fetch                               Install fetch to easily download files, folders, and release assets from a specific git commit, branch, or tag
+  figurine                            Install figurine foir printing your name in style
   github-commenter                    Install github-commenter
   github-release                      Install github-release to create and edit releases on Github (and upload artifacts)
   gomplate                            Install gomplate

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -8,7 +8,7 @@ Available targets:
   chamber                             Install Chamber to manage secrets with SSM+KMS
   cloudflared                         Install cloudflared which offers an easy way to expose web servers securely to the internet(Argo Tunnel)
   fetch                               Install fetch to easily download files, folders, and release assets from a specific git commit, branch, or tag
-  figurine                            Install figurine foir printing your name in style
+  figurine                            Install figurine to generate fancy colorized ASCII banners
   ghr                                 Install ghr to easily upload multiple artifacts to GitHub Release
   ghr-darwin                          Install ghr to easily upload multiple artifacts to GitHub Release (Darwin)
   ghr-linux                           Install ghr to easily upload multiple artifacts to GitHub Release (Linux)

--- a/install/Makefile
+++ b/install/Makefile
@@ -141,6 +141,22 @@ export HUGO_VERSION ?= 0.45.1
 hugo: hugo-$(OS)
 	@exit 0
 
+export FIGURINE_VERSION ?= 0.2.2
+## Install figurine foir printing your name in style (darwin)
+figurine-darwin:
+	$(CURL) -o - https://github.com/arsham/figurine/releases/download/v$(FIGURINE_VERSION)/figurine_darwin_v$(FIGURINE_VERSION).tar.gz | tar -zxO  figurine > $(INSTALL_PATH)/figurine
+	chmod +x $(INSTALL_PATH)/figurine
+
+## Install figurine foir printing your name in style (linux)
+figurine-linux:
+	$(CURL) -o - https://github.com/arsham/figurine/releases/download/v$(FIGURINE_VERSION)/figurine_linux_v$(FIGURINE_VERSION).tar.gz | tar -zxO  figurine > $(INSTALL_PATH)/figurine
+	chmod +x $(INSTALL_PATH)/figurine
+
+# Releases: https://github.com/arsham/figurine/releases
+## Install figurine foir printing your name in style
+figurine: figurine-$(OS)
+	@exit 0
+
 export KOPS_VERSION ?= 1.9.2
 # Releases: https://github.com/kubernetes/kops/releases
 ## Install kops

--- a/install/Makefile
+++ b/install/Makefile
@@ -29,7 +29,8 @@ all: awless \
 	 terraform \
 	 terraform-docs \
 	 terragrunt \
-	 yq
+	 yq \
+	 figurine
 
 export AWLESS_VERSION ?= 0.1.11
 # Releases: https://github.com/wallix/awless/releases

--- a/install/Makefile
+++ b/install/Makefile
@@ -145,7 +145,7 @@ hugo: hugo-$(OS)
 
 export FIGURINE_VERSION ?= 0.2.2
 # Releases: https://github.com/arsham/figurine/releases
-## Install figurine foir printing your name in style
+## Install figurine for generate fancy colorized ASCII banners
 figurine: 
 	$(CURL) -o - https://github.com/arsham/figurine/releases/download/v$(FIGURINE_VERSION)/figurine_$(OS)_v$(FIGURINE_VERSION).tar.gz | tar -zxO  figurine > $(INSTALL_PATH)/figurine
 	chmod +x $(INSTALL_PATH)/figurine

--- a/install/Makefile
+++ b/install/Makefile
@@ -143,20 +143,11 @@ hugo: hugo-$(OS)
 	@exit 0
 
 export FIGURINE_VERSION ?= 0.2.2
-## Install figurine foir printing your name in style (darwin)
-figurine-darwin:
-	$(CURL) -o - https://github.com/arsham/figurine/releases/download/v$(FIGURINE_VERSION)/figurine_darwin_v$(FIGURINE_VERSION).tar.gz | tar -zxO  figurine > $(INSTALL_PATH)/figurine
-	chmod +x $(INSTALL_PATH)/figurine
-
-## Install figurine foir printing your name in style (linux)
-figurine-linux:
-	$(CURL) -o - https://github.com/arsham/figurine/releases/download/v$(FIGURINE_VERSION)/figurine_linux_v$(FIGURINE_VERSION).tar.gz | tar -zxO  figurine > $(INSTALL_PATH)/figurine
-	chmod +x $(INSTALL_PATH)/figurine
-
 # Releases: https://github.com/arsham/figurine/releases
 ## Install figurine foir printing your name in style
-figurine: figurine-$(OS)
-	@exit 0
+figurine: 
+	$(CURL) -o - https://github.com/arsham/figurine/releases/download/v$(FIGURINE_VERSION)/figurine_$(OS)_v$(FIGURINE_VERSION).tar.gz | tar -zxO  figurine > $(INSTALL_PATH)/figurine
+	chmod +x $(INSTALL_PATH)/figurine
 
 export KOPS_VERSION ?= 1.9.2
 # Releases: https://github.com/kubernetes/kops/releases

--- a/install/Makefile
+++ b/install/Makefile
@@ -145,7 +145,7 @@ hugo: hugo-$(OS)
 
 export FIGURINE_VERSION ?= 0.2.2
 # Releases: https://github.com/arsham/figurine/releases
-## Install figurine for generate fancy colorized ASCII banners
+## Install figurine to generate fancy colorized ASCII banners
 figurine: 
 	$(CURL) -o - https://github.com/arsham/figurine/releases/download/v$(FIGURINE_VERSION)/figurine_$(OS)_v$(FIGURINE_VERSION).tar.gz | tar -zxO  figurine > $(INSTALL_PATH)/figurine
 	chmod +x $(INSTALL_PATH)/figurine


### PR DESCRIPTION
## what
* add targets which can install `figurine`

## why
* To replace the banner we already use in `geodesic`

## references
- https://github.com/cloudposse/packages/issues/30