### PR TITLE
[lectl] Add target for installing new package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
+
+
+
+
+
 ## Usage
 
 See all available packages:
@@ -128,6 +133,7 @@ Available targets:
   kubectl                             Install kubectl
   kubectx                             Install kubectx
   kubens                              Install kubens
+  lectl                               Install lectl script to check issued certificates by Let's Encrypt on CTL
   sops                                Install sops (required by `helm-secrets`)
   stern                               Install stern multi pod and container log tailing for Kubernetes
   terraform                           Install Terraform
@@ -154,11 +160,11 @@ Check out these related projects.
 
 File a GitHub [issue](https://github.com/cloudposse/packages/issues), send us an [email][email] or join our [Slack Community][slack].
 
-## Commerical Support
+## Commercial Support
 
 Work directly with our team of DevOps experts via email, slack, and video conferencing. 
 
-We provide *commercial support* for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a fulltime engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)](mailto:hello@cloudposse.com)
 
@@ -168,7 +174,7 @@ We provide *commercial support* for all of our [Open Source][github] projects. A
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll develop original modules to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
 
 
 ## Community Forum
@@ -226,6 +232,13 @@ See [LICENSE](LICENSE) for full details.
     under the License.
 
 
+
+
+
+
+
+
+
 ## Trademarks
 
 All other trademarks referenced herein are the property of their respective owners.
@@ -245,6 +258,7 @@ Check out [our other projects][github], [apply for a job][jobs], or [hire us][hi
   [docs]: https://docs.cloudposse.com/
   [website]: https://cloudposse.com/
   [github]: https://github.com/cloudposse/
+  [commercial_support]: https://github.com/orgs/cloudposse/projects
   [jobs]: https://cloudposse.com/jobs/
   [hire]: https://cloudposse.com/contact/
   [slack]: https://slack.cloudposse.com/

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -23,6 +23,7 @@ Available targets:
   kubectl                             Install kubectl
   kubectx                             Install kubectx
   kubens                              Install kubens
+  lectl                               Install lectl script to check issued certificates by Let's Encrypt on CTL
   sops                                Install sops (required by `helm-secrets`)
   stern                               Install stern multi pod and container log tailing for Kubernetes
   terraform                           Install Terraform

--- a/install/Makefile
+++ b/install/Makefile
@@ -29,7 +29,8 @@ all: awless \
 	 terraform \
 	 terraform-docs \
 	 terragrunt \
-	 yq
+	 yq \
+	 lectl
 
 export AWLESS_VERSION ?= 0.1.11
 # Releases: https://github.com/wallix/awless/releases
@@ -140,6 +141,13 @@ export HUGO_VERSION ?= 0.45.1
 ## Install hugo framework for building static websites.
 hugo: hugo-$(OS)
 	@exit 0
+
+export LECTL_VERSION ?= 0.16
+# Releases: https://github.com/sahsanu/lectl/releases
+## Install lectl script to check issued certificates by Let's Encrypt on CTL
+lectl:
+	$(CURL) -o - https://github.com/sahsanu/lectl/archive/v$(LECTL_VERSION).tar.gz | tar -zxO  lectl-${LECTL_VERSION}/lectl > $(INSTALL_PATH)/lectl
+	chmod +x $(INSTALL_PATH)/lectl
 
 export KOPS_VERSION ?= 1.9.2
 # Releases: https://github.com/kubernetes/kops/releases

--- a/install/Makefile
+++ b/install/Makefile
@@ -142,11 +142,10 @@ export HUGO_VERSION ?= 0.45.1
 hugo: hugo-$(OS)
 	@exit 0
 
-export LECTL_VERSION ?= 0.16
 # Releases: https://github.com/sahsanu/lectl/releases
 ## Install lectl script to check issued certificates by Let's Encrypt on CTL
 lectl:
-	$(CURL) -o - https://github.com/sahsanu/lectl/archive/v$(LECTL_VERSION).tar.gz | tar -zxO  lectl-${LECTL_VERSION}/lectl > $(INSTALL_PATH)/lectl
+	$(CURL) -o - https://raw.githubusercontent.com/sahsanu/lectl/master/lectl > $(INSTALL_PATH)/lectl
 	chmod +x $(INSTALL_PATH)/lectl
 
 export KOPS_VERSION ?= 1.9.2

--- a/install/Makefile
+++ b/install/Makefile
@@ -143,10 +143,11 @@ export HUGO_VERSION ?= 0.45.1
 hugo: hugo-$(OS)
 	@exit 0
 
+export LECTL_VERSION ?= 0.16
 # Releases: https://github.com/sahsanu/lectl/releases
 ## Install lectl script to check issued certificates by Let's Encrypt on CTL
 lectl:
-	$(CURL) -o - https://raw.githubusercontent.com/sahsanu/lectl/master/lectl > $(INSTALL_PATH)/lectl
+	$(CURL) -o - https://raw.githubusercontent.com/sahsanu/lectl/v$(LECTL_VERSION)/lectl > $(INSTALL_PATH)/lectl
 	chmod +x $(INSTALL_PATH)/lectl
 
 # Releases: https://developers.cloudflare.com/argo-tunnel/downloads/


### PR DESCRIPTION
## what
* add targets which can install `lectl`

## why
* Make it easier to triage Lets Encrypt certificates

## references
- https://github.com/cloudposse/packages/issues/33