### PR TITLE
[gitleaks] Add target for installing new package

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Available targets:
   ghr-linux                           Install ghr to easily upload multiple artifacts to GitHub Release (Linux)
   github-commenter                    Install github-commenter
   github-release                      Install github-release to create and edit releases on Github (and upload artifacts)
+  gitleaks                            Install gitleaks to audit git repos for secrets
   gomplate                            Install gomplate
   goofys                              Install goofys
   helm                                Install helm

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -13,6 +13,7 @@ Available targets:
   ghr-linux                           Install ghr to easily upload multiple artifacts to GitHub Release (Linux)
   github-commenter                    Install github-commenter
   github-release                      Install github-release to create and edit releases on Github (and upload artifacts)
+  gitleaks                            Install gitleaks to audit git repos for secrets
   gomplate                            Install gomplate
   goofys                              Install goofys
   helm                                Install helm

--- a/install/Makefile
+++ b/install/Makefile
@@ -231,7 +231,7 @@ ghr: ghr-$(OS)
 
 export GITLEAKS_VERSION ?= 1.2.0
 # Releases: https://github.com/zricethezav/gitleaks/releases
-## Install library, which audit git repos for secrets
+## Install audit git repos for secrets
 gitleaks:
 	$(call github_download_binary_release,zricethezav,v$(GITLEAKS_VERSION),$@-$(OS)-$(ARCH))
 

--- a/install/Makefile
+++ b/install/Makefile
@@ -231,7 +231,7 @@ ghr: ghr-$(OS)
 
 export GITLEAKS_VERSION ?= 1.2.0
 # Releases: https://github.com/zricethezav/gitleaks/releases
-## Install audit git repos for secrets
+## Install gitleaks to audit git repos for secrets
 gitleaks:
 	$(call github_download_binary_release,zricethezav,v$(GITLEAKS_VERSION),$@-$(OS)-$(ARCH))
 

--- a/install/Makefile
+++ b/install/Makefile
@@ -229,6 +229,12 @@ ghr-linux:
 ghr: ghr-$(OS)
 	@exit 0
 
+export GITLEAKS_VERSION ?= 1.2.0
+# Releases: https://github.com/zricethezav/gitleaks/releases
+## Install library, which audit git repos for secrets
+gitleaks:
+	$(call github_download_binary_release,zricethezav,v$(GITLEAKS_VERSION),$@-$(OS)-$(ARCH))
+
 .PHONY : help
 help:
 	@printf "Available targets:\n\n"


### PR DESCRIPTION
## what
* Add `gitleaks`

## why
* Useful for scanning code for leaks of credentials

## references 
- https://github.com/cloudposse/packages/issues/40