### PR TITLE
Fix OS Compatibility

### DIFF
--- a/install/Makefile
+++ b/install/Makefile
@@ -1,7 +1,7 @@
 INSTALL_PATH ?= /usr/local/bin
 VENDOR_PATH ?= ../vendor
 
-all: $(shell find $(VENDOR_PATH) -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort )
+all: $(shell find $(VENDOR_PATH) -maxdepth 1 -mindepth 1 -type d | xargs -n 1 basename | sort )
 	@exit 0
 
 ## Install a specific package


### PR DESCRIPTION
## what
* `find: unrecognized: -printf`

## why
* BusyBox linux distros have simpler `find` command