### PR TITLE
Prevent env vars naming conflicts

### DIFF
--- a/apk/templates/APKBUILD.github-binary
+++ b/apk/templates/APKBUILD.github-binary
@@ -1,6 +1,6 @@
 # Contributor: Cloud Posse, LLC <hello@cloudposse.com>
 # Maintainer: Cloud Posse, LLC <hello@cloudposse.com>
-pkgname=${NAME}
+pkgname=${PACKAGE_NAME}
 pkgver=${VERSION}
 pkgrel=${RELEASE}
 pkgdesc="${DESCRIPTION}"

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -9,9 +9,9 @@ export PATH := $(PATH):../../bin/
 export TMP ?= /tmp
 
 # Package details
-export NAME ?= $(notdir $(CURDIR))
-export REPO_NAME ?= $(NAME)
-export EXE ?= $(NAME)
+export PACKAGE_NAME ?= $(notdir $(CURDIR))
+export REPO_NAME ?= $(PACKAGE_NAME)
+export EXE ?= $(PACKAGE_NAME)
 export DESCRIPTION ?= $(shell cat DESCRIPTION 2>/dev/null)
 export VERSION ?= $(shell cat VERSION 2>/dev/null)
 export RELEASE ?= $(shell cat RELEASE 2>/dev/null)
@@ -27,32 +27,32 @@ endif
 
 # Macros to download a binary release from GitHub and install it
 # $(call github_download_binary_release,version,repo,asset)
-download_binary = $(CURL) -o $(INSTALL_PATH)/$(NAME) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(NAME)
+download_binary = $(CURL) -o $(INSTALL_PATH)/$(PACKAGE_NAME) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
 define download_tarball
-	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
-	mkdir -p $(TMP)/$(NAME)
-	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
-	chmod +x $(INSTALL_PATH)/$(NAME)
-	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
+	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
+	mkdir -p $(TMP)/$(PACKAGE_NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C $(TMP)/$(PACKAGE_NAME)
+	find $(TMP)/$(PACKAGE_NAME) -type f -name $(PACKAGE_NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(PACKAGE_NAME)
+	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
+	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 endef
 
 define download_tar_bz2
-	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
-	mkdir -p $(TMP)/$(NAME)
-	$(CURL) -o - $(DOWNLOAD_URL) | tar -jx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
-	chmod +x $(INSTALL_PATH)/$(NAME)
-	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
+	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
+	mkdir -p $(TMP)/$(PACKAGE_NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar -jx -C $(TMP)/$(PACKAGE_NAME)
+	find $(TMP)/$(PACKAGE_NAME) -type f -name $(PACKAGE_NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(PACKAGE_NAME)
+	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
+	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 endef
 
 define download_tar_xz
-	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
-	mkdir -p $(TMP)/$(NAME)
-	$(CURL) -o - $(DOWNLOAD_URL) | tar -Jx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
-	chmod +x $(INSTALL_PATH)/$(NAME)
-	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
+	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
+	mkdir -p $(TMP)/$(PACKAGE_NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar -Jx -C $(TMP)/$(PACKAGE_NAME)
+	find $(TMP)/$(PACKAGE_NAME) -type f -name $(PACKAGE_NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(PACKAGE_NAME)
+	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
+	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 endef
 
 
@@ -83,7 +83,7 @@ update: update/version update/license update/description update/release
 
 info:
 	@printf "%-20s %s\n" "Vendor:" "$(VENDOR)"
-	@printf "%-20s %s\n" "Package:" "$(NAME)"
+	@printf "%-20s %s\n" "Package:" "$(PACKAGE_NAME)"
 	@printf "%-20s %s\n" "Version:" "$(VERSION)"
 	@printf "%-20s %s\n" "License:" "$(LICENSE)"
 	@printf "%-20s %s\n" "Arch:" "$(ARCH)"
@@ -94,4 +94,4 @@ info:
 	@printf "%-20s %s\n" "Install Path:" "$(INSTALL_PATH)"
 
 info/short:
-	@printf "%-25s %-10s %s\n" "$(NAME)" "$(VERSION)" "$(DESCRIPTION)"
+	@printf "%-25s %-10s %s\n" "$(PACKAGE_NAME)" "$(VERSION)" "$(DESCRIPTION)"

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -9,7 +9,7 @@ export PATH := $(PATH):../../bin/
 export TMP ?= /tmp
 
 # Package details
-export NAME ?= $(notdir $(CURDIR))
+export NAME = $(notdir $(CURDIR))
 export REPO_NAME ?= $(NAME)
 export EXE ?= $(NAME)
 export DESCRIPTION ?= $(shell cat DESCRIPTION 2>/dev/null)

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -32,7 +32,7 @@ define download_tarball
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C $(TMP)/$(NAME)
-	cp $(TMP)/$(NAME)/$(NAME) $(INSTALL_PATH)/$(NAME)
+	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef
@@ -41,7 +41,7 @@ define download_tar_bz2
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -jx -C $(TMP)/$(NAME)
-	cp $(TMP)/$(NAME)/$(NAME) $(INSTALL_PATH)/$(NAME)
+	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef
@@ -50,7 +50,7 @@ define download_tar_xz
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -Jx -C $(TMP)/$(NAME)
-	cp $(TMP)/$(NAME)/$(NAME) $(INSTALL_PATH)/$(NAME)
+	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -28,9 +28,9 @@ endif
 # Macros to download a binary release from GitHub and install it
 # $(call github_download_binary_release,version,repo,asset)
 download_binary = $(CURL) -o $(INSTALL_PATH)/$(NAME) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tarball = $(CURL) -o - $(DOWNLOAD_URL) | tar -zxO -T $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tar_bz2 = $(CURL) -o - $(DOWNLOAD_URL) | tar -jxO -T $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tar_xz = $(CURL) -o - $(DOWNLOAD_URL) | tar -JxO -T $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+download_tarball = $(CURL) -o - $(DOWNLOAD_URL) | tar -zxO $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+download_tar_bz2 = $(CURL) -o - $(DOWNLOAD_URL) | tar -jxO $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+download_tar_xz = $(CURL) -o - $(DOWNLOAD_URL) | tar -JxO $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
 
 default: info
 

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -28,9 +28,33 @@ endif
 # Macros to download a binary release from GitHub and install it
 # $(call github_download_binary_release,version,repo,asset)
 download_binary = $(CURL) -o $(INSTALL_PATH)/$(NAME) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tarball = $(CURL) -o - $(DOWNLOAD_URL) | tar -zxO $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tar_bz2 = $(CURL) -o - $(DOWNLOAD_URL) | tar -jxO $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tar_xz = $(CURL) -o - $(DOWNLOAD_URL) | tar -JxO $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+define download_tarball
+	rm -rf $(TMP)/$(NAME)
+	mkdir -p $(TMP)/$(NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C $(TMP)/$(NAME)
+	cp $(TMP)/$(NAME)/$(NAME) $(INSTALL_PATH)/$(NAME)
+	chmod +x $(INSTALL_PATH)/$(NAME)
+	rm -rf $(TMP)/$(NAME)
+endef
+
+define download_tar_bz2
+	rm -rf $(TMP)/$(NAME)
+	mkdir -p $(TMP)/$(NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar -jx -C $(TMP)/$(NAME)
+	cp $(TMP)/$(NAME)/$(NAME) $(INSTALL_PATH)/$(NAME)
+	chmod +x $(INSTALL_PATH)/$(NAME)
+	rm -rf $(TMP)/$(NAME)
+endef
+
+define download_tar_xz
+	rm -rf $(TMP)/$(NAME)
+	mkdir -p $(TMP)/$(NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar -Jx -C $(TMP)/$(NAME)
+	cp $(TMP)/$(NAME)/$(NAME) $(INSTALL_PATH)/$(NAME)
+	chmod +x $(INSTALL_PATH)/$(NAME)
+	rm -rf $(TMP)/$(NAME)
+endef
+
 
 default: info
 

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -32,7 +32,7 @@ define download_tarball
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME)
+	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME);
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef
@@ -41,7 +41,7 @@ define download_tar_bz2
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -jx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME)
+	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME);
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef
@@ -50,7 +50,7 @@ define download_tar_xz
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -Jx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME)
+	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME);
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -28,9 +28,9 @@ endif
 # Macros to download a binary release from GitHub and install it
 # $(call github_download_binary_release,version,repo,asset)
 download_binary = $(CURL) -o $(INSTALL_PATH)/$(NAME) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tarball = $(CURL) -o - $(DOWNLOAD_URL) | tar --wildcards -zxO *$(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tar_bz2 = $(CURL) -o - $(DOWNLOAD_URL) | tar --wildcards -jxO *$(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
-download_tar_xz = $(CURL) -o - $(DOWNLOAD_URL) | tar --wildcards -JxO *$(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+download_tarball = $(CURL) -o - $(DOWNLOAD_URL) | tar -zxO -T $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+download_tar_bz2 = $(CURL) -o - $(DOWNLOAD_URL) | tar -jxO -T $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+download_tar_xz = $(CURL) -o - $(DOWNLOAD_URL) | tar -JxO -T $(NAME) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
 
 default: info
 

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -32,7 +32,7 @@ define download_tarball
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME);
+	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef
@@ -41,7 +41,7 @@ define download_tar_bz2
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -jx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME);
+	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef
@@ -50,7 +50,7 @@ define download_tar_xz
 	rm -rf $(TMP)/$(NAME)
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -Jx -C $(TMP)/$(NAME)
-	find $(TMP)/$(NAME) -type f -name $(NAME) -exec cp -f {} $(INSTALL_PATH)/$(NAME);
+	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
 	rm -rf $(TMP)/$(NAME)
 endef

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -9,7 +9,7 @@ export PATH := $(PATH):../../bin/
 export TMP ?= /tmp
 
 # Package details
-export NAME = $(notdir $(CURDIR))
+export NAME ?= $(notdir $(CURDIR))
 export REPO_NAME ?= $(NAME)
 export EXE ?= $(NAME)
 export DESCRIPTION ?= $(shell cat DESCRIPTION 2>/dev/null)
@@ -29,30 +29,30 @@ endif
 # $(call github_download_binary_release,version,repo,asset)
 download_binary = $(CURL) -o $(INSTALL_PATH)/$(NAME) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(NAME)
 define download_tarball
-	rm -rf $(TMP)/$(NAME)
+	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C $(TMP)/$(NAME)
 	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
-	rm -rf $(TMP)/$(NAME)
+	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
 endef
 
 define download_tar_bz2
-	rm -rf $(TMP)/$(NAME)
+	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -jx -C $(TMP)/$(NAME)
 	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
-	rm -rf $(TMP)/$(NAME)
+	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
 endef
 
 define download_tar_xz
-	rm -rf $(TMP)/$(NAME)
+	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
 	mkdir -p $(TMP)/$(NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -Jx -C $(TMP)/$(NAME)
 	find $(TMP)/$(NAME) -type f -name $(NAME) | xargs -I {} cp -f {} $(INSTALL_PATH)/$(NAME)
 	chmod +x $(INSTALL_PATH)/$(NAME)
-	rm -rf $(TMP)/$(NAME)
+	[ -n "$(TMP)" ] && [ -n "$(NAME)" ] && rm -rf "$(TMP)/$(NAME)"
 endef
 
 

--- a/vendor/atlantis/Makefile
+++ b/vendor/atlantis/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= runatlantis
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(OS)_$(ARCH).zip
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(OS)_$(ARCH).zip
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/awless/Makefile
+++ b/vendor/awless/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= wallix
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-$(OS)-$(ARCH).tar.gz
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-$(OS)-$(ARCH).tar.gz
 
 include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk

--- a/vendor/aws-vault/Makefile
+++ b/vendor/aws-vault/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= 99designs
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-$(OS)-$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-$(OS)-$(ARCH)
 export CHECK_COMMAND_ARGUMENTS ?= --version
 export CHECK_COMMAND_ENV ?= HOME=./
 

--- a/vendor/chamber/Makefile
+++ b/vendor/chamber/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= segmentio
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-v$(VERSION)-$(OS)-$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-v$(VERSION)-$(OS)-$(ARCH)
 export CHECK_COMMAND_ARGUMENTS ?= version
 
 include ../../tasks/Makefile.package

--- a/vendor/cli53/Makefile
+++ b/vendor/cli53/Makefile
@@ -9,7 +9,7 @@ endif
 
 # Package details
 export VENDOR ?= barnybug
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)-$(OS)-$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)-$(OS)-$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 

--- a/vendor/cloudflared/Makefile
+++ b/vendor/cloudflared/Makefile
@@ -4,7 +4,7 @@ include ../../tasks/Makefile.apk
 # Package details
 export VENDOR ?= cloudflare
 export HOMEPAGE_URL = https://developers.cloudflare.com/argo-tunnel/downloads/
-export DOWNLOAD_URL ?= https://bin.equinox.io/c/VdrWdbjqyF/$(NAME)-stable-$(OS)-$(ARCH).tgz
+export DOWNLOAD_URL ?= https://bin.equinox.io/c/VdrWdbjqyF/$(PACKAGE_NAME)-stable-$(OS)-$(ARCH).tgz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 

--- a/vendor/codefresh/Makefile
+++ b/vendor/codefresh/Makefile
@@ -7,16 +7,14 @@ ifeq ($(OS),darwin)
 endif
 
 ifeq ($(DISTR),alpine)
-	FLAVOR=$(DISTR)
-else
-	FLAVOR=$(OS)
+	OS=alpine
 endif
 
 export VENDOR ?= codefresh-io
 export REPO_NAME ?= cli
 export NAME ?= codefresh
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/codefresh-v$(VERSION)-$(FLAVOR)-x64.tar.gz
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/codefresh-v$(VERSION)-$(OS)-x64.tar.gz
 export APKBUILD_DEPENDS += ca-certificates
 
 ## Required for testing on build

--- a/vendor/codefresh/Makefile
+++ b/vendor/codefresh/Makefile
@@ -7,7 +7,7 @@ ifeq ($(OS),darwin)
 endif
 
 ifeq ($(DISTR),alpine)
-	FLAVOR=alpine
+	FLAVOR=$(DISTR)
 else
 	FLAVOR=$(OS)
 endif

--- a/vendor/codefresh/Makefile
+++ b/vendor/codefresh/Makefile
@@ -26,7 +26,7 @@ include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk
 
 install:
-	$(call download_tarball)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar -zxO $(NAME)-$(OS) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
 
 test:
 	$(EXE) version

--- a/vendor/codefresh/Makefile
+++ b/vendor/codefresh/Makefile
@@ -7,14 +7,16 @@ ifeq ($(OS),darwin)
 endif
 
 ifeq ($(DISTR),alpine)
-	OS=alpine
+	FLAVOR=alpine
+else
+	FLAVOR=$(OS)
 endif
 
 export VENDOR ?= codefresh-io
 export REPO_NAME ?= cli
 export NAME ?= codefresh
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/codefresh-v$(VERSION)-$(OS)-x64.tar.gz
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/codefresh-v$(VERSION)-$(FLAVOR)-x64.tar.gz
 export APKBUILD_DEPENDS += ca-certificates
 
 ## Required for testing on build

--- a/vendor/codefresh/Makefile
+++ b/vendor/codefresh/Makefile
@@ -26,7 +26,7 @@ include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk
 
 install:
-	$(CURL) -o - $(DOWNLOAD_URL) | tar -zxO $(NAME)-$(OS) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+	$(call download_tarball)
 
 test:
 	$(EXE) version

--- a/vendor/codefresh/Makefile
+++ b/vendor/codefresh/Makefile
@@ -12,7 +12,6 @@ endif
 
 export VENDOR ?= codefresh-io
 export REPO_NAME ?= cli
-export NAME ?= codefresh
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/codefresh-v$(VERSION)-$(OS)-x64.tar.gz
 export APKBUILD_DEPENDS += ca-certificates

--- a/vendor/ctop/Makefile
+++ b/vendor/ctop/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= bcicen
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-$(VERSION)-$(OS)-$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-$(VERSION)-$(OS)-$(ARCH)
 export APKBUILD_DEPENDS += libc6-compat
 
 include ../../tasks/Makefile.package

--- a/vendor/fargate/Makefile
+++ b/vendor/fargate/Makefile
@@ -3,14 +3,14 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= jpignata
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-$(VERSION)-$(OS)-$(ARCH).zip
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-$(VERSION)-$(OS)-$(ARCH).zip
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:
-	$(CURL) -o - $(DOWNLOAD_URL) > $(TMP)/$(NAME).zip
-	unzip -p $(TMP)/$(NAME).zip $(NAME) > $(INSTALL_PATH)/$(NAME)
-	rm $(TMP)/$(NAME).zip
-	chmod +x $(INSTALL_PATH)/$(NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) > $(TMP)/$(PACKAGE_NAME).zip
+	unzip -p $(TMP)/$(PACKAGE_NAME).zip $(PACKAGE_NAME) > $(INSTALL_PATH)/$(PACKAGE_NAME)
+	rm $(TMP)/$(PACKAGE_NAME).zip
+	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
 
 test:
 	$(EXE) --version

--- a/vendor/fetch/Makefile
+++ b/vendor/fetch/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= gruntwork-io
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(OS)_$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(OS)_$(ARCH)
 
 include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk

--- a/vendor/figurine/Makefile
+++ b/vendor/figurine/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= arsham
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(OS)_v$(VERSION).tar.gz 
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(OS)_v$(VERSION).tar.gz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 

--- a/vendor/ghr/Makefile
+++ b/vendor/ghr/Makefile
@@ -9,7 +9,7 @@ endif
 
 # Package details
 export VENDOR ?= tcnksm
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_v$(VERSION)_$(OS)_$(ARCH).$(EXTENSION)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_v$(VERSION)_$(OS)_$(ARCH).$(EXTENSION)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install: install-$(OS)

--- a/vendor/github-commenter/Makefile
+++ b/vendor/github-commenter/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= cloudposse
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)_$(OS)_$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)_$(OS)_$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 

--- a/vendor/github-release/Makefile
+++ b/vendor/github-release/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= aktau
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(OS)-$(ARCH)-$(NAME).tar.bz2
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(OS)-$(ARCH)-$(PACKAGE_NAME).tar.bz2
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/gitleaks/Makefile
+++ b/vendor/gitleaks/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= zricethezav
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-$(OS)-$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-$(OS)-$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/gometalinter/Makefile
+++ b/vendor/gometalinter/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= alecthomas
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-$(VERSION)-$(OS)-$(ARCH).tar.gz
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-$(VERSION)-$(OS)-$(ARCH).tar.gz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:
@@ -13,4 +13,4 @@ test:
 	$(EXE) --version
 
 package/prepare::
-	mv src/$(NAME)-$(VERSION)-$(OS)-$(ARCH)/$(NAME) src
+	mv src/$(PACKAGE_NAME)-$(VERSION)-$(OS)-$(ARCH)/$(PACKAGE_NAME) src

--- a/vendor/gomplate/Makefile
+++ b/vendor/gomplate/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= hairyhenderson
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(OS)-$(ARCH)-slim
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(OS)-$(ARCH)-slim
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/goofys/Makefile
+++ b/vendor/goofys/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= kahing
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 

--- a/vendor/gosu/Makefile
+++ b/vendor/gosu/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= tianon
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)-$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)-$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/gotop/Makefile
+++ b/vendor/gotop/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= cjbassi
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)_$(VERSION)_$(OS)_$(ARCH).tgz
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)_$(VERSION)_$(OS)_$(ARCH).tgz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 

--- a/vendor/helm/Makefile
+++ b/vendor/helm/Makefile
@@ -7,10 +7,10 @@ export DOWNLOAD_URL ?= http://storage.googleapis.com/kubernetes-helm/helm-v$(VER
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:
-	mkdir -p $(TMP)/$(NAME)
-	$(CURL) -o - $(DOWNLOAD_URL) | tar -C $(TMP)/$(NAME) -zx $(OS)-$(ARCH)/helm
-	mv $(TMP)/$(NAME)/$(OS)-$(ARCH)/helm $(INSTALL_PATH)/$(NAME)
-	rm -rf $(TMP)/$(NAME)
+	mkdir -p $(TMP)/$(PACKAGE_NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar -C $(TMP)/$(PACKAGE_NAME) -zx $(OS)-$(ARCH)/helm
+	mv $(TMP)/$(PACKAGE_NAME)/$(OS)-$(ARCH)/helm $(INSTALL_PATH)/$(PACKAGE_NAME)
+	rm -rf $(TMP)/$(PACKAGE_NAME)
 	chmod +x $(INSTALL_PATH)/helm
 
 test:

--- a/vendor/helmfile/Makefile
+++ b/vendor/helmfile/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= roboll
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(OS)_$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(OS)_$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/htmltest/Makefile
+++ b/vendor/htmltest/Makefile
@@ -7,7 +7,7 @@ endif
 
 # Package details
 export VENDOR ?= wjdp
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(VERSION)_$(OS)_$(ARCH).tar.gz
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(VERSION)_$(OS)_$(ARCH).tar.gz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 

--- a/vendor/hugo/Makefile
+++ b/vendor/hugo/Makefile
@@ -9,7 +9,7 @@ endif
 
 # Package details
 export VENDOR ?= gohugoio
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(VERSION)_$(OS)-64bit.tar.gz
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(VERSION)_$(OS)-64bit.tar.gz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/json2hcl/Makefile
+++ b/vendor/json2hcl/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= kvz
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_v$(VERSION)_$(OS)_$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_v$(VERSION)_$(OS)_$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/k6/Makefile
+++ b/vendor/k6/Makefile
@@ -12,19 +12,19 @@ endif
 
 # Package details
 export VENDOR ?= loadimpact
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-v$(VERSION)-$(OS).$(EXT)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-v$(VERSION)-$(OS).$(EXT)
 export APK_BUILD_TEMPLATE ?= AP KBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 
 install-mac:
-	$(CURL) -o - $(DOWNLOAD_URL) > $(INSTALL_PATH)/$(NAME).zip
-	unzip -p $(INSTALL_PATH)/$(NAME).zip */$(NAME) > $(INSTALL_PATH)/$(NAME)
-	rm $(INSTALL_PATH)/$(NAME).zip
-	chmod +x $(INSTALL_PATH)/$(NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) > $(INSTALL_PATH)/$(PACKAGE_NAME).zip
+	unzip -p $(INSTALL_PATH)/$(PACKAGE_NAME).zip */$(PACKAGE_NAME) > $(INSTALL_PATH)/$(PACKAGE_NAME)
+	rm $(INSTALL_PATH)/$(PACKAGE_NAME).zip
+	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
 
 install-linux64:
-	$(CURL) -o - $(DOWNLOAD_URL) | tar --wildcards -zxO */$(NAME) > $(INSTALL_PATH)/$(NAME)
-	chmod +x $(INSTALL_PATH)/$(NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar --wildcards -zxO */$(PACKAGE_NAME) > $(INSTALL_PATH)/$(PACKAGE_NAME)
+	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
 
 install: install-$(OS)
 	@exit 0
@@ -33,4 +33,4 @@ test:
 	$(EXE) version
 
 package/prepare::
-	mv src/$(NAME)-v$(VERSION)-$(OS)/$(NAME) src/$(NAME)
+	mv src/$(PACKAGE_NAME)-v$(VERSION)-$(OS)/$(PACKAGE_NAME) src/$(PACKAGE_NAME)

--- a/vendor/kops/Makefile
+++ b/vendor/kops/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= kubernetes
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)-$(OS)-$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)-$(OS)-$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/kubectl/Makefile
+++ b/vendor/kubectl/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= kubernetes
-export DOWNLOAD_URL ?= https://storage.googleapis.com/kubernetes-release/release/v$(VERSION)/bin/$(OS)/$(ARCH)/$(NAME)
+export DOWNLOAD_URL ?= https://storage.googleapis.com/kubernetes-release/release/v$(VERSION)/bin/$(OS)/$(ARCH)/$(PACKAGE_NAME)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/kubectx/Makefile
+++ b/vendor/kubectx/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= ahmetb
-export DOWNLOAD_URL ?= https://raw.githubusercontent.com/ahmetb/$(NAME)/v$(VERSION)/$(NAME)
+export DOWNLOAD_URL ?= https://raw.githubusercontent.com/ahmetb/$(PACKAGE_NAME)/v$(VERSION)/$(PACKAGE_NAME)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += bash
 

--- a/vendor/kubens/Makefile
+++ b/vendor/kubens/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= ahmetb
 export REPO_NAME ?= kubectx
-export DOWNLOAD_URL ?= https://raw.githubusercontent.com/ahmetb/kubectx/v$(VERSION)/$(NAME)
+export DOWNLOAD_URL ?= https://raw.githubusercontent.com/ahmetb/kubectx/v$(VERSION)/$(PACKAGE_NAME)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += bash
 

--- a/vendor/misspell/Makefile
+++ b/vendor/misspell/Makefile
@@ -7,7 +7,7 @@ endif
 
 # Package details
 export VENDOR ?= client9
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(VERSION)_$(OS)_64bit.tar.gz
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(VERSION)_$(OS)_64bit.tar.gz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/packer/Makefile
+++ b/vendor/packer/Makefile
@@ -3,14 +3,14 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= hashicorp
-export DOWNLOAD_URL ?= https://releases.hashicorp.com/$(NAME)/$(VERSION)/$(NAME)_$(VERSION)_$(OS)_$(ARCH).zip
+export DOWNLOAD_URL ?= https://releases.hashicorp.com/$(PACKAGE_NAME)/$(VERSION)/$(PACKAGE_NAME)_$(VERSION)_$(OS)_$(ARCH).zip
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:
-	$(CURL) -o - $(DOWNLOAD_URL) > $(INSTALL_PATH)/$(NAME).zip
-	unzip -p $(INSTALL_PATH)/$(NAME).zip $(NAME) > $(INSTALL_PATH)/$(NAME)
-	rm $(INSTALL_PATH)/$(NAME).zip
-	chmod +x $(INSTALL_PATH)/$(NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) > $(INSTALL_PATH)/$(PACKAGE_NAME).zip
+	unzip -p $(INSTALL_PATH)/$(PACKAGE_NAME).zip $(PACKAGE_NAME) > $(INSTALL_PATH)/$(PACKAGE_NAME)
+	rm $(INSTALL_PATH)/$(PACKAGE_NAME).zip
+	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
 
 test:
 	$(EXE) --version

--- a/vendor/slack-notifier/Makefile
+++ b/vendor/slack-notifier/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= cloudposse
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)_$(OS)_$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)_$(OS)_$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 

--- a/vendor/slack-notifier/Makefile
+++ b/vendor/slack-notifier/Makefile
@@ -8,6 +8,7 @@ export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 
 install:
+	echo $(DOWNLOAD_URL)
 	$(call download_binary)
 
 test:

--- a/vendor/slack-notifier/Makefile
+++ b/vendor/slack-notifier/Makefile
@@ -8,7 +8,6 @@ export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APKBUILD_DEPENDS += libc6-compat
 
 install:
-	echo $(DOWNLOAD_URL)
 	$(call download_binary)
 
 test:

--- a/vendor/sops/Makefile
+++ b/vendor/sops/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= mozilla
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)-$(VERSION).$(OS)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)-$(VERSION).$(OS)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/stern/Makefile
+++ b/vendor/stern/Makefile
@@ -3,7 +3,7 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= wercker
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)_$(OS)_$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)_$(OS)_$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:

--- a/vendor/teleport/Makefile
+++ b/vendor/teleport/Makefile
@@ -9,7 +9,7 @@ export APKBUILD_DEPENDS += libc6-compat musl
 export EXE = teleport tctl tsh
 
 install:
-	$(CURL) -o - $(DOWNLOAD_URL) | tar --wildcards -zxO $(addprefix teleport/,$(EXE)) > $(INSTALL_PATH)/$(NAME) && chmod +x $(INSTALL_PATH)/$(NAME)
+	$(CURL) -o - $(DOWNLOAD_URL) | tar --wildcards -zxO $(addprefix teleport/,$(EXE)) > $(INSTALL_PATH)/$(PACKAGE_NAME) && chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
 
 test:
 	teleport version

--- a/vendor/terraform-docs/Makefile
+++ b/vendor/terraform-docs/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= segmentio
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)-v$(VERSION)-$(OS)-$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)-v$(VERSION)-$(OS)-$(ARCH)
 
 include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk

--- a/vendor/terraform/Makefile
+++ b/vendor/terraform/Makefile
@@ -3,16 +3,16 @@ include ../../tasks/Makefile.apk
 
 # Package details
 export VENDOR ?= hashicorp
-export DOWNLOAD_URL ?= https://releases.hashicorp.com/$(NAME)/$(VERSION)/$(NAME)_$(VERSION)_$(OS)_$(ARCH).zip 
+export DOWNLOAD_URL ?= https://releases.hashicorp.com/$(PACKAGE_NAME)/$(VERSION)/$(PACKAGE_NAME)_$(VERSION)_$(OS)_$(ARCH).zip
 	## Run go generate in all packages
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
 install:
-	mkdir -p $(TMP)/$(NAME)
-	$(CURL) -o $(TMP)/$(NAME)/terraform.zip $(DOWNLOAD_URL)
-	unzip -d $(TMP)/$(NAME) $(TMP)/$(NAME)/$(NAME).zip
-	mv $(TMP)/$(NAME)/$(NAME) $(INSTALL_PATH)/$(NAME)
-	chmod +x $(INSTALL_PATH)/$(NAME)
+	mkdir -p $(TMP)/$(PACKAGE_NAME)
+	$(CURL) -o $(TMP)/$(PACKAGE_NAME)/terraform.zip $(DOWNLOAD_URL)
+	unzip -d $(TMP)/$(PACKAGE_NAME) $(TMP)/$(PACKAGE_NAME)/$(PACKAGE_NAME).zip
+	mv $(TMP)/$(PACKAGE_NAME)/$(PACKAGE_NAME) $(INSTALL_PATH)/$(PACKAGE_NAME)
+	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
 
 test:
 	$(EXE) version

--- a/vendor/terragrunt/Makefile
+++ b/vendor/terragrunt/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= gruntwork-io
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(NAME)_$(OS)_$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/v$(VERSION)/$(PACKAGE_NAME)_$(OS)_$(ARCH)
 
 include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk

--- a/vendor/yq/Makefile
+++ b/vendor/yq/Makefile
@@ -1,7 +1,7 @@
 # Package details
 export VENDOR ?= mikefarah
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
-export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(NAME)_$(OS)_$(ARCH)
+export DOWNLOAD_URL ?= $(REPO_URL)/releases/download/$(VERSION)/$(PACKAGE_NAME)_$(OS)_$(ARCH)
 
 include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk


### PR DESCRIPTION
## What
* Replace `NAME` variable with `PACKAGE_NAME` 

## Why
* To prevent conflicts between `build-harness` `slack notification` module and `packages`
* To prevent env vars naming conflicts in future.