### PR TITLE
Only distribute when PACKAGES are present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ deps:
 ## Create a distribution by coping $PACKAGES from $INSTALL_PATH to $DIST_PATH
 dist:
 	mkdir -p $(DIST_PATH)
-	cd $(INSTALL_PATH) && $(DIST_CMD) $(PACKAGES) $(DIST_PATH)
+	@[ -n "$(PACKAGES)" ] && \
+		cd $(INSTALL_PATH) && \
+		$(DIST_CMD) $(PACKAGES) $(DIST_PATH)
 
 build:
 	@make --no-print-directory docker:build


### PR DESCRIPTION
## what
* Check if packages are present before attempting to distribute

## why
* If `PACKAGES` are empty, `make dist` fails. 
* In `geodesic` we have a build `ARG` which may be empty