### PR TITLE
fix repo name

### DIFF
--- a/apk/templates/APKBUILD.github-binary
+++ b/apk/templates/APKBUILD.github-binary
@@ -7,6 +7,7 @@ pkgrel=${PACKAGE_RELEASE}
 pkgdesc="${PACKAGE_DESCRIPTION}"
 builddir="$srcdir"
 exe=$PACKAGE_EXE
+repo=vendor
 
 # https://wiki.alpinelinux.org/wiki/APKBUILD_examples
 

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -22,6 +22,7 @@ list/all:
 
 ## Build all updated alpine packages
 build:
+	chmod 777 ../tmp
 	$(MAKE) --no-print-directory -s $(BUILD_LIST_TARGET) | \
 		xargs -t -n 1 -I{} -- /bin/sh -c 'make --no-print-directory -C {} info apk || exit 255'
 


### PR DESCRIPTION
## what
* hardcode repo to `vendor`

## why
* #165 broke this by moving to a temp folder. `abuild` [extrapolates the repo name](https://github.com/alpinelinux/abuild/blob/master/abuild.in#L2554-L2555) from the parent folder. this makes it explicit.