### PR TITLE
Take extra steps to preserve /packages/tmp/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,5 @@
 *.iml
 .build-harness
 build-harness
-tmp
+# We are relying on tmp and must include it
+tmp/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,5 @@ COPY --from=cfssl /go/bin/ ${INSTALL_PATH}/
 
 COPY . /packages
 RUN mkdir -p /packages/tmp
-RUN make -C /packages/install/ terraform
+RUN make -C /packages/install/ all
 WORKDIR /packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --update --no-cache bash make curl coreutils libc6-compat tar xz
 
 COPY --from=cfssl /go/bin/ ${INSTALL_PATH}/
 
-ADD . /packages
-RUN make -C /packages/install/ all
+COPY . /packages
+RUN mkdir -p /packages/tmp
+RUN make -C /packages/install/ terraform
 WORKDIR /packages

--- a/tasks/Makefile.apk
+++ b/tasks/Makefile.apk
@@ -26,6 +26,7 @@ apk/build:
 apk/clean:
 	@find $(APK_PACKAGES_PATH) -type f -name APKINDEX.tar.gz -delete
 	rm -rf $(APK_TMP_DIR)
+	mkdir -p $(APK_TMP_DIR)
 
 apk: apk/prepare apk/checksum apk/build apk/clean
 	@exit 0


### PR DESCRIPTION
## what
Take extra steps to ensure `/packages/tmp/` gets created and is not deleted. Closes #174 
## why
`/packages/tmp/` is required by the build process but is subject to deletion or non-inclusion due to filters such as `.gitignore` or `.dockerignore` or commands like `rm -rf $TMPDIR`. Ideally we should not be using `tmp` as the directory name so we do not run into these hidden problems where a downstream `.dockerignore` might interfere with the creation of a `tmp` directory, but it is used extensively and so renaming it is left for the future.