### PR TITLE
[terraform-0.11] fix vendor repo

### DIFF
--- a/vendor/terraform-0.11/APKBUILD
+++ b/vendor/terraform-0.11/APKBUILD
@@ -7,6 +7,7 @@ pkgrel="${PACKAGE_RELEASE}"
 mjrver=${pkgver%.*}
 pkgname="terraform_${mjrver}"
 pkgdesc="${PACKAGE_DESCRIPTION}"
+repo=vendor
 arch="x86_64"
 url="https://releases.hashicorp.com/terraform/${pkgver}/terraform_${pkgver}_linux_amd64.zip"
 license="MPL-2.0"


### PR DESCRIPTION
## what
* explicitly set `repo=vendor`

## why
* Since we build the packages in a `tmp` folder, the derived repo name is incorrect
* The `APKBUILD` configuration used here is not the same one the other projects use, which is why the oversight happened