### PR TITLE
Build APKINDEX.tar.gz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ docker/build/apk/shell:
 		--name apkbuild \
 		--rm \
 		-it \
+		-e AWS_SECRET_ACCESS_KEY \
+		-e AWS_ACCESS_KEY_ID \
+		-e AWS_SESSION_TOKEN \
+		-e AWS_SECURITY_TOKEN \
 		-e APK_PACKAGES_PATH=/packages/artifacts/$(ALPINE_VERSION) \
 		--privileged \
 		-w /packages \

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -1,5 +1,3 @@
 export:
-	cf_export CURRENT_BRANCH=$(CF_BRANCH)
-	cf_export PACKAGER_PRIVKEY=/dev/shm/key.rsa
 	echo "$(KEY_RSA)" | base64 -d > /dev/shm/key.rsa
 	echo "$(KEY_RSA_PUB)" | base64 -d > /dev/shm/key.rsa.pub

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -5,7 +5,7 @@ export:
 
 ## Restore mtime
 mtime:
-	git ls-tree -r --name-only HEAD | while read filename; do \
+	git ls-tree -r --name-only HEAD ../ | while read filename; do \
 	  unixtime=$$(git log -1 --format="%at" -- $$filename); \
 	  touchtime=$$(date -d @$$unixtime +'%Y%m%d%H%M.%S'); \
 	  touch -t $$touchtime $$filename; \

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -1,7 +1,8 @@
+export PACKAGER_PRIVKEY=$(CF_VOLUME_PATH)/key.rsa
 export:
-	@echo "$(KEY_RSA)" | base64 -d > /dev/shm/key.rsa
-	@echo "$(KEY_RSA_PUB)" | base64 -d > /dev/shm/key.rsa.pub
-	@echo PACKAGER_PRIVKEY=/dev/shm/key.rsa >> $(CF_VOLUME_PATH)/env_vars_to_export
+	@echo "$(KEY_RSA)" | base64 -d > $(PACKAGER_PRIVKEY)
+	@echo "$(KEY_RSA_PUB)" | base64 -d > $(PACKAGER_PRIVKEY).pub
+	@echo PACKAGER_PRIVKEY=$(PACKAGER_PRIVKEY) >> $(CF_VOLUME_PATH)/env_vars_to_export
 
 ## Restore mtime
 mtime:

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -1,4 +1,4 @@
 export:
 	@echo "$(KEY_RSA)" | base64 -d > /dev/shm/key.rsa
 	@echo "$(KEY_RSA_PUB)" | base64 -d > /dev/shm/key.rsa.pub
-	@cf_export PACKAGER_PRIVKEY=/dev/shm/key.rsa
+	@echo PACKAGER_PRIVKEY=/dev/shm/key.rsa >> $(CF_VOLUME_PATH)/env_vars_to_export

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -1,5 +1,5 @@
 export:
-	cf_export CURRENT_BRANCH=${{CF_BRANCH}}
+	cf_export CURRENT_BRANCH=$(CF_BRANCH)
 	cf_export PACKAGER_PRIVKEY=/dev/shm/key.rsa
-	echo "${{KEY_RSA}}" | base64 -d > /dev/shm/key.rsa
-	echo "${{KEY_RSA_PUB}}" | base64 -d > /dev/shm/key.rsa.pub
+	echo "$(KEY_RSA)" | base64 -d > /dev/shm/key.rsa
+	echo "$(KEY_RSA_PUB)" | base64 -d > /dev/shm/key.rsa.pub

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -2,3 +2,11 @@ export:
 	@echo "$(KEY_RSA)" | base64 -d > /dev/shm/key.rsa
 	@echo "$(KEY_RSA_PUB)" | base64 -d > /dev/shm/key.rsa.pub
 	@echo PACKAGER_PRIVKEY=/dev/shm/key.rsa >> $(CF_VOLUME_PATH)/env_vars_to_export
+
+## Restore mtime
+mtime:
+	git ls-tree -r --name-only HEAD | while read filename; do \
+	  unixtime=$$(git log -1 --format="%at" -- $$filename); \
+	  touchtime=$$(date -d @$$unixtime +'%Y%m%d%H%M.%S'); \
+	  touch -t $$touchtime $$filename; \
+	done

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -1,0 +1,5 @@
+export:
+	cf_export CURRENT_BRANCH=${{CF_BRANCH}}
+	cf_export PACKAGER_PRIVKEY=/dev/shm/key.rsa
+	echo "${{KEY_RSA}}" | base64 -d > /dev/shm/key.rsa
+	echo "${{KEY_RSA_PUB}}" | base64 -d > /dev/shm/key.rsa.pub

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -1,3 +1,3 @@
 export:
-	echo "$(KEY_RSA)" | base64 -d > /dev/shm/key.rsa
-	echo "$(KEY_RSA_PUB)" | base64 -d > /dev/shm/key.rsa.pub
+	@echo "$(KEY_RSA)" | base64 -d > /dev/shm/key.rsa
+	@echo "$(KEY_RSA_PUB)" | base64 -d > /dev/shm/key.rsa.pub

--- a/codefresh/Makefile
+++ b/codefresh/Makefile
@@ -1,3 +1,4 @@
 export:
 	@echo "$(KEY_RSA)" | base64 -d > /dev/shm/key.rsa
 	@echo "$(KEY_RSA_PUB)" | base64 -d > /dev/shm/key.rsa.pub
+	@cf_export PACKAGER_PRIVKEY=/dev/shm/key.rsa

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -24,6 +24,7 @@ steps:
     commands:
       - make -C codefresh export
       - aws s3 sync --exclude '*' --include '*.apk' --size-only "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
+      - make -C vendor deindex
       - chown -R nobody "${APK_PACKAGES_PATH}"
 
   docker_build:
@@ -72,9 +73,7 @@ steps:
         working_directory: .
         environment:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.7
-          - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
-          - make -C vendor deindex
           - make -C vendor build
           - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
@@ -86,9 +85,7 @@ steps:
         working_directory: .
         environment:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.8
-          - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
-          - make -C vendor deindex
           - make -C vendor build
           - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
@@ -100,9 +97,7 @@ steps:
         working_directory: .
         environment:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.9
-          - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
-          - make -C vendor deindex
           - make -C vendor build
           - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -71,6 +71,7 @@ steps:
         working_directory: .
         environment:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.7
+          - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
           - make -C vendor build
           - make -C vendor index
@@ -83,6 +84,7 @@ steps:
         working_directory: .
         environment:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.8
+          - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
           - make -C vendor build
           - make -C vendor index
@@ -95,6 +97,7 @@ steps:
         working_directory: .
         environment:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.9
+          - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
           - make -C vendor build
           - make -C vendor index

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -6,19 +6,19 @@ stages:
 steps:
 
   main_clone:
+    title: "Clone respository"
+    type: git-clone
+    stage: Prepare
+    description: "Initialize"
+    repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
+    git: CF-default
+    revision: ${{CF_REVISION}}
+
+  main_clone:
     type: "parallel"
     title: "Prepare Build Environment"
     stage: Prepare
     steps:
-      git_clone:
-        title: "Clone respository"
-        type: git-clone
-        stage: Prepare
-        description: "Initialize"
-        repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
-        git: CF-default
-        revision: ${{CF_REVISION}}
-
       init_variables:
         title: Init variables
         stage: Prepare
@@ -39,7 +39,7 @@ steps:
         environment:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
         commands:
-          - aws s3 sync --acl public-read --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
+          - aws s3 sync --include '*.apk' --exclude '*' --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
 
   docker_build:
     type: "parallel"

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -24,6 +24,7 @@ steps:
     commands:
       - make -C codefresh export
       - aws s3 sync --exclude '*' --include '*.apk' --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
+      - chown -R nobody "${APK_PACKAGES_PATH}"
 
   docker_build:
     type: "parallel"

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -23,7 +23,7 @@ steps:
       - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
     commands:
       - make -C codefresh export
-      - aws s3 sync --exclude '*' --include '*.apk' --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
+      - aws s3 sync --exclude '*' --include '*.apk' --size-only "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
       - chown -R nobody "${APK_PACKAGES_PATH}"
 
   docker_build:
@@ -74,6 +74,7 @@ steps:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.7
           - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
+          - make -C vendor deindex
           - make -C vendor build
           - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
@@ -87,6 +88,7 @@ steps:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.8
           - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
+          - make -C vendor deindex
           - make -C vendor build
           - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
@@ -100,6 +102,7 @@ steps:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.9
           - PACKAGER_PRIVKEY=/dev/shm/key.rsa
         commands:
+          - make -C vendor deindex
           - make -C vendor build
           - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -23,7 +23,7 @@ steps:
       - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
     commands:
       - make -C codefresh export mtime
-      - aws s3 sync --exclude '*' --include '*.apk' --size-only "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
+      - aws s3 sync --exclude '*' --include '*.apk' --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
       - make -C vendor deindex
       - chown -R nobody "${APK_PACKAGES_PATH}"
 

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -39,7 +39,7 @@ steps:
         environment:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
         commands:
-          - aws s3 sync --include '*.apk' --exclude '*' --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
+          - aws s3 sync --exclude '*' --include '*.apk' --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
 
   docker_build:
     type: "parallel"

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -100,7 +100,7 @@ steps:
         commands:
           - make -C vendor build
           - make -C vendor index
-          - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
+           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' -exec ls -l {} +
  
   # Only deploy on merge to master
   publish:

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -22,7 +22,7 @@ steps:
     environment:
       - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
     commands:
-      - make -C codefresh export
+      - make -C codefresh export mtime
       - aws s3 sync --exclude '*' --include '*.apk' --size-only "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
       - make -C vendor deindex
       - chown -R nobody "${APK_PACKAGES_PATH}"

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -4,26 +4,42 @@ stages:
   - Build
   - Publish
 steps:
-  main_clone:
-    title: "Clone respository"
-    type: git-clone
-    stage: Prepare
-    description: "Initialize"
-    repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
-    git: CF-default
-    revision: ${{CF_REVISION}}
 
-  init_variables:
-    title: Init variables
+  main_clone:
+    type: "parallel"
+    title: "Prepare Build Environment"
     stage: Prepare
-    image: alpine
-    working_directory: .
-    environment:
-      - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
-    commands:
-      - cf_export CURRENT_BRANCH=${{CF_BRANCH}}
-      - echo "${{KEY_RSA}}" | base64 -d > key.rsa
-      - echo "${{KEY_RSA_PUB}}" | base64 -d > key.rsa.pub
+    steps:
+      git_clone:
+        title: "Clone respository"
+        type: git-clone
+        stage: Prepare
+        description: "Initialize"
+        repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
+        git: CF-default
+        revision: ${{CF_REVISION}}
+
+      init_variables:
+        title: Init variables
+        stage: Prepare
+        image: alpine
+        working_directory: .
+        environment:
+          - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
+        commands:
+          - cf_export CURRENT_BRANCH=${{CF_BRANCH}}
+          - echo "${{KEY_RSA}}" | base64 -d > key.rsa
+          - echo "${{KEY_RSA_PUB}}" | base64 -d > key.rsa.pub
+
+      pull:
+        title: Pull down all existing packages from S3 bucket
+        stage: Prepare
+        image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
+        working_directory: ./
+        environment:
+          - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
+        commands:
+          - aws s3 sync --acl public-read --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
 
   docker_build:
     type: "parallel"
@@ -73,6 +89,7 @@ steps:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.7
         commands:
           - make -C vendor build
+          - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
 
       apk_build_3_8:
@@ -84,6 +101,7 @@ steps:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.8
         commands:
           - make -C vendor build
+          - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
 
       apk_build_3_9:
@@ -95,9 +113,10 @@ steps:
           - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts/3.9
         commands:
           - make -C vendor build
+          - make -C vendor index
           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
  
-    # Only deploy on merge to master
+  # Only deploy on merge to master
   publish:
     title: Push all apk artifacts to S3 bucket
     stage: Publish

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -76,7 +76,7 @@ steps:
         commands:
           - make -C vendor build
           - make -C vendor index
-          - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
+          - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' -exec ls -l {} \;
 
       apk_build_3_8:
         title: Build alpine 3.8 packages
@@ -88,7 +88,7 @@ steps:
         commands:
           - make -C vendor build
           - make -C vendor index
-          - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' | xargs ls -l 
+          - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' -exec ls -l {} \;
 
       apk_build_3_9:
         title: Build alpine 3.9 packages
@@ -100,7 +100,7 @@ steps:
         commands:
           - make -C vendor build
           - make -C vendor index
-           - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' -exec ls -l {} +
+          - find "${APK_PACKAGES_PATH}" -type f -name '*.apk' -exec ls -l {} \;
  
   # Only deploy on merge to master
   publish:

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -14,7 +14,7 @@ steps:
     git: CF-default
     revision: ${{CF_REVISION}}
 
-  main_clone:
+  main_env:
     type: "parallel"
     title: "Prepare Build Environment"
     stage: Prepare

--- a/codefresh/apk.yml
+++ b/codefresh/apk.yml
@@ -14,32 +14,16 @@ steps:
     git: CF-default
     revision: ${{CF_REVISION}}
 
-  main_env:
-    type: "parallel"
-    title: "Prepare Build Environment"
+  stage:
+    title: Pull down all existing packages from S3 bucket
     stage: Prepare
-    steps:
-      init_variables:
-        title: Init variables
-        stage: Prepare
-        image: alpine
-        working_directory: .
-        environment:
-          - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
-        commands:
-          - cf_export CURRENT_BRANCH=${{CF_BRANCH}}
-          - echo "${{KEY_RSA}}" | base64 -d > key.rsa
-          - echo "${{KEY_RSA_PUB}}" | base64 -d > key.rsa.pub
-
-      pull:
-        title: Pull down all existing packages from S3 bucket
-        stage: Prepare
-        image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
-        working_directory: ./
-        environment:
-          - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
-        commands:
-          - aws s3 sync --exclude '*' --include '*.apk' --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
+    image: cloudposse/build-harness:${{BUILD_HARNESS_VERSION}}
+    working_directory: ./
+    environment:
+      - APK_PACKAGES_PATH=${{CF_VOLUME_PATH}}/artifacts
+    commands:
+      - make -C codefresh export
+      - aws s3 sync --exclude '*' --include '*.apk' --exact-timestamps "s3://${S3_BUCKET_NAME}/" "${APK_PACKAGES_PATH}/"
 
   docker_build:
     type: "parallel"

--- a/tasks/Makefile.apk
+++ b/tasks/Makefile.apk
@@ -1,5 +1,5 @@
 # APK
-export PACKAGER_PRIVKEY = $(CURDIR)/../../key.rsa
+export PACKAGER_PRIVKEY ?= $(CURDIR)/../../key.rsa
 export APK_TEMPLATE_PATH ?= ../../apk/templates/
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APK_PACKAGES_PATH ?= /tmp/packages

--- a/tasks/Makefile.apk
+++ b/tasks/Makefile.apk
@@ -40,9 +40,8 @@ apk: $(APK_PACKAGE)
 # Rebuild the `.apk` when it's older than the Makefile, VERSION, or RELEASE files
 $(APK_PACKAGE): Makefile VERSION RELEASE
 	@echo "Building $@"
-	ls -l $@ || true
-	ls -l Makefile VERSION RELEASE
-#	$(MAKE) info apk/prepare apk/checksum apk/build apk/clean
+	ls -l $@ Makefile VERSION RELEASE || true
+	$(MAKE) info apk/prepare apk/checksum apk/build apk/clean
 
 package/prepare::
 	@exit 0

--- a/tasks/Makefile.apk
+++ b/tasks/Makefile.apk
@@ -41,6 +41,7 @@ apk: $(APK_PACKAGE)
 $(APK_PACKAGE): Makefile VERSION RELEASE
 	@echo "Building $@"
 	ls -l $@ || true
+	ls -l Makefile VERSION RELEASE
 #	$(MAKE) info apk/prepare apk/checksum apk/build apk/clean
 
 package/prepare::

--- a/tasks/Makefile.apk
+++ b/tasks/Makefile.apk
@@ -40,7 +40,8 @@ apk: $(APK_PACKAGE)
 # Rebuild the `.apk` when it's older than the Makefile, VERSION, or RELEASE files
 $(APK_PACKAGE): Makefile VERSION RELEASE
 	@echo "Building $@"
-	$(MAKE) info apk/prepare apk/checksum apk/build apk/clean
+	ls -l $@ || true
+#	$(MAKE) info apk/prepare apk/checksum apk/build apk/clean
 
 package/prepare::
 	@exit 0

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -5,7 +5,7 @@ APK_PACKAGE_REPOS ?= $(addprefix $(APK_PACKAGES_PATH)/,$(REPOS))
 APK_PACKAGE_INDEX ?= $(addsuffix /APKINDEX.tar.gz,$(APK_PACKAGE_REPOS))
 APK_PACKAGES ?= $(wildcard $(addsuffix /*.apk,$(APK_PACKAGE_REPOS)))
 
-export PACKAGER_PRIVKEY = $(CURDIR)/../key.rsa
+export PACKAGER_PRIVKEY ?= $(CURDIR)/../key.rsa
 
 default: build
 

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -35,6 +35,10 @@ $(APK_PACKAGE_INDEX): $(APK_PACKAGES)
 
 index: $(APK_PACKAGE_INDEX)
 
+# Drop indexes
+deindex:
+	@find $(APK_PACKAGES_PATH) -type f -name APKINDEX.tar.gz -delete
+
 ## Show available packages
 help:
 	@find . -mindepth 1 -maxdepth 1 -type d | sort -u | xargs -I{} make --no-print-directory -s -C {} info/short

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -1,5 +1,12 @@
 PACKAGES  = $(sort $(dir $(wildcard */)))
 
+REPOS = vendor/x86_64
+APK_PACKAGE_REPOS ?= $(addprefix $(APK_PACKAGES_PATH)/,$(REPOS))
+APK_PACKAGE_INDEX ?= $(addsuffix /APKINDEX.tar.gz,$(APK_PACKAGE_REPOS))
+APK_PACKAGES ?= $(wildcard $(addsuffix /*.apk,$(APK_PACKAGE_REPOS)))
+
+export PACKAGER_PRIVKEY = $(CURDIR)/../key.rsa
+
 default: build
 
 ## Install alpine build deps
@@ -18,6 +25,15 @@ $(PACKAGES): prepare
 ## Update all packages
 update:
 	find . -mindepth 1 -maxdepth 1 -type d | xargs -I{} make -C {} update
+
+# Rebuild the APKINDEX if it's older than any of the *.apk files
+$(APK_PACKAGE_INDEX): $(APK_PACKAGES)
+	rm -f $(@).tmp
+	apk index -o $(@).tmp $(dir $@)/*.apk
+	abuild-sign -k $(PACKAGER_PRIVKEY) $(@).tmp
+	mv -f $(@).tmp $(@)
+
+index: $(APK_PACKAGE_INDEX)
 
 ## Show available packages
 help:


### PR DESCRIPTION
## what
* Build `APKINDEX.tar.gz` in codefresh
* Restore `mtime` after `git clone` so that builds are faster because `make` can determine what needs updating

## why
* We've been using `alpinist` for some time, but it appears to suffer from bad race conditions whereby packages are inappropriately signed
* Using a lambda to generate the index is convoluted and difficult to debug. 
* With codefresh building the package index everything is self-contained
* We can soon enable Cloudflare caching and then cache bust after deployment

## highlevel

1. pull down all apks
2. build new apks (based on mtime when `.apk` is older than `Makefile`, `VERSION` or `RELEASE`)
3. push apks back up (when on master)

## references
* https://stackoverflow.com/questions/21735435/git-clone-changes-file-modification-time