### PR TITLE
Fix update target

### DIFF
--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -109,7 +109,10 @@ RELEASE: VERSION LICENSE DESCRIPTION
 
 init: VERSION LICENSE DESCRIPTION RELEASE
 
-update: VERSION RELEASE
+reset:
+	rm -f VERSION RELEASE
+
+update: reset VERSION RELEASE
 
 info:
 	@printf "%-20s %s\n" "Vendor:" "$(VENDOR)"


### PR DESCRIPTION
## what
* Fix update target

## why
* The update target depends on `VERSION` and `RELEASE`, but these won't be updated if they are found, so we reset the configs before attempting to refresh them.