### PR TITLE
Better isolation for package builds

### DIFF
--- a/tasks/Makefile.apk
+++ b/tasks/Makefile.apk
@@ -6,15 +6,16 @@ export APK_PACKAGES_PATH ?= /tmp/packages
 export APK_TMP_DIR := $(realpath $(shell mktemp -d ../../tmp/build.XXXXXX))
 export APK_PACKAGE_NAME ?= $(PACKAGE_NAME)
 export APK_PACKAGE ?= $(APK_PACKAGES_PATH)/vendor/x86_64/$(APK_PACKAGE_NAME)-$(PACKAGE_VERSION)-r$(PACKAGE_RELEASE).apk
+export SRCDEST := $(APK_TMP_DIR)/cache
 
 apk/prepare::
-	mkdir -p $(APK_PACKAGES_PATH) $(APK_TMP_DIR)
+	mkdir -p $(APK_PACKAGES_PATH) $(APK_TMP_DIR) $(SRCDEST)
 	chmod 777 $(APK_PACKAGES_PATH) $(APK_TMP_DIR)
 	cp -a $(APK_TEMPLATE_PATH)/$(APK_BUILD_TEMPLATE) $(APK_TMP_DIR)/APKBUILD
 	cp -a . "$(APK_TMP_DIR)"
 	chsh -s /bin/sh nobody
 	chown nobody -R $(APK_TMP_DIR)
-	chmod 777 /var/cache/distfiles
+	chmod 777 $(SRCDEST)
 
 apk/checksum:
 	cd $(APK_TMP_DIR) && \

--- a/vendor/kops/Makefile
+++ b/vendor/kops/Makefile
@@ -2,6 +2,7 @@ include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk
 
 # Package details
+# This package tracks the most advanced production-ready version of kops
 export VENDOR ?= kubernetes
 export DOWNLOAD_URL ?= $(PACKAGE_REPO_URL)/releases/download/$(PACKAGE_VERSION)/$(PACKAGE_NAME)-$(OS)-$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary


### PR DESCRIPTION
## what
Explicitly set `SRCDEST` to a temporary directory unique to each package.

## why
Prevent different versions of the same artifact from being confused with each other.