### PR TITLE
Add post-install scripts as dependencies

### DIFF
--- a/tasks/Makefile.apk
+++ b/tasks/Makefile.apk
@@ -69,7 +69,7 @@ apk: $(PACKAGER_PRIVKEY) $(PACKAGER_PUBKEY_INSTALLED) $(APK_PACKAGE)
 	@exit 0
 
 # Rebuild the `.apk` when it's older than the Makefile, VERSION, or RELEASE files
-$(APK_PACKAGE): Makefile VERSION RELEASE
+$(APK_PACKAGE): Makefile VERSION RELEASE $(wildcard *.post-install) $(wildcard *.post-deinstall)
 	@echo "Building $@"
 	ls -l $@ Makefile VERSION RELEASE || true
 	$(MAKE) info apk/prepare apk/checksum apk/build apk/testinstall apk/clean

--- a/vendor/cloudposse-atlantis/cloudposse-atlantis.post-install
+++ b/vendor/cloudposse-atlantis/cloudposse-atlantis.post-install
@@ -1,6 +1,6 @@
 #!/bin/sh
-# This is an Alpine Package `post-install` hook that links
-# an alternative from `/usr/share/${PACKAGE_NAME}/$version/bin` into `/usr/bin/`
+# This is an Alpine Package `post-install` hook that links an alternative
+# from `/usr/share/${PACKAGE_NAME}/$version/bin` into `/usr/bin/`
 MASTER_PACKAGE_NAME=atlantis
 PACKAGE_NAME=cloudposse-atlantis
 VENDOR=cloudposse


### PR DESCRIPTION
## what
Rebuild packages if their post-install or post-deinstall scripts change

## why
No use in preserving packages with buggy scripts