### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Here's a stub you can include into a `Makefile` to make it easier to install bin
 ```
 export PACKAGES_VERSION ?= master
 export PACKAGES_PATH ?= packages/
-export INSTALL_PATH ?= $(PACKAGES_PATH)/vendor
+export INSTALL_PATH ?= $(PACKAGES_PATH)/bin
 
 ## Install packages
 packages/install:

--- a/README.yaml
+++ b/README.yaml
@@ -158,7 +158,7 @@ examples: |-
   ```
   export PACKAGES_VERSION ?= master
   export PACKAGES_PATH ?= packages/
-  export INSTALL_PATH ?= $(PACKAGES_PATH)/vendor
+  export INSTALL_PATH ?= $(PACKAGES_PATH)/bin
 
   ## Install packages
   packages/install:

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -30,12 +30,17 @@ endif
 
 # Macros to download a binary release from GitHub and install it
 # $(call github_download_binary_release,version,repo,asset)
-download_binary = $(CURL) -o $(INSTALL_PATH)/$(PACKAGE_NAME) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
+define download_binary
+	mkdir -p $(INSTALL_PATH)
+	$(CURL) -o $(INSTALL_PATH)/$(PACKAGE_NAME) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
+endef
 
 define download_binary_gz
+	mkdir -p $(INSTALL_PATH)
 	$(CURL) -o $(INSTALL_PATH)/$(PACKAGE_NAME).gz $(DOWNLOAD_URL)
 	gunzip -f -k -q $(INSTALL_PATH)/$(PACKAGE_NAME).gz
 	chmod +x $(INSTALL_PATH)/$(PACKAGE_NAME)
+	rm -f $(INSTALL_PATH)/$(PACKAGE_NAME).gz
 endef
 
 define download_tarball


### PR DESCRIPTION
## what
* Fix macros in `README.yaml` examples
* Use `packages/bin` as an example installation target instead of `packages/vendor`

## why
* Attempting to set `INSTALL_PATH=packages/vendor` will usually fail because the directory for the package will exist and we're trying to write the binary file to the same name

## references
* #266 - identified problem with documentation