### PR TITLE
Update dockerfiles to point to new alpine repo for 3.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export README_DEPS ?= .github/auto-label.yml docs/targets.md
 
 export DIST_CMD ?= cp -a
 export DIST_PATH ?= /dist
-export ALPINE_VERSION ?= 3.10
+export ALPINE_VERSION ?= 3.11
 
 SHELL := /bin/bash
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Add the following to your `Dockerfile` near the top.
 ```
 # Install the cloudposse alpine repository
 ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
-RUN echo "@cloudposse https://apk.cloudposse.com/3.10/vendor" >> /etc/apk/repositories
+RUN echo "@cloudposse https://apk.cloudposse.com/3.11/vendor" >> /etc/apk/repositories
 ```
-__NOTE__: we support alpine `3.7`, `3.8`, `3.9`, and `3.10` packages at this time
+__NOTE__: we support alpine `3.7`, `3.8`, `3.9`, `3.10`, and `3.11` packages at this time
 
 ### Installing Alpine Packages
 

--- a/README.yaml
+++ b/README.yaml
@@ -75,9 +75,9 @@ usage: |-
   ```
   # Install the cloudposse alpine repository
   ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
-  RUN echo "@cloudposse https://apk.cloudposse.com/3.10/vendor" >> /etc/apk/repositories
+  RUN echo "@cloudposse https://apk.cloudposse.com/3.11/vendor" >> /etc/apk/repositories
   ```
-  __NOTE__: we support alpine `3.7`, `3.8`, `3.9`, and `3.10` packages at this time
+  __NOTE__: we support alpine `3.7`, `3.8`, `3.9`, `3.10`, and `3.11` packages at this time
 
   ### Installing Alpine Packages
   

--- a/apk/Dockerfile-3.11
+++ b/apk/Dockerfile-3.11
@@ -2,7 +2,7 @@ FROM alpine:3.11
 
 # Install the cloudposse alpine repository
 ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
-RUN echo "https://apk.cloudposse.com/3.10/vendor" >> /etc/apk/repositories
+RUN echo "https://apk.cloudposse.com/3.11/vendor" >> /etc/apk/repositories
 RUN echo "https://alpine.global.ssl.fastly.net/alpine/edge/testing" >> /etc/apk/repositories
 RUN echo "https://alpine.global.ssl.fastly.net/alpine/edge/community" >> /etc/apk/repositories
 


### PR DESCRIPTION
## what
* Update dockerfiles to point to new 3.11 repo

## why
* Chicken-and-the-egg problem: we cannot create a new release that depends on the release existing, so we first create the release pointing at the previous version and then flip it after merging #313 

## references
* closes #311  (also isn't that the perfect ticket number for this issue!!)
* #308 
* #313

![image](https://user-images.githubusercontent.com/52489/72091310-b7fcd380-32c4-11ea-984f-30ca8439fe92.png)
