### PR TITLE
Add `dpkg` dependency for helm alternatives

### DIFF
--- a/vendor/helm/Makefile
+++ b/vendor/helm/Makefile
@@ -5,6 +5,7 @@ include ../../tasks/Makefile.apk
 export VENDOR ?= helm
 export DOWNLOAD_URL ?= https://get.helm.sh/helm-v$(PACKAGE_VERSION)-$(OS)-$(ARCH).tar.gz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
+export APKBUILD_DEPENDS += dpkg
 export APKBUILD_INSTALL_SCRIPTS = $(PACKAGE_NAME).post-install $(PACKAGE_NAME).post-deinstall
 export MAJOR_VERSION = latest
 export INSTALL_DIR = /usr/share/${PACKAGE_NAME}/${MAJOR_VERSION}/bin

--- a/vendor/helm2/Makefile
+++ b/vendor/helm2/Makefile
@@ -11,6 +11,7 @@ include ../../tasks/Makefile.apk
 export VENDOR ?= helm
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export AUTO_UPDATE_ENABLED = false
+export APKBUILD_DEPENDS += dpkg
 export APKBUILD_INSTALL_SCRIPTS = $(PACKAGE_NAME).post-install $(PACKAGE_NAME).post-deinstall
 export INSTALL_DIR = /usr/share/${MASTER_PACKAGE_NAME}/${MAJOR_VERSION}/bin
 

--- a/vendor/helm3/Makefile
+++ b/vendor/helm3/Makefile
@@ -11,6 +11,7 @@ include ../../tasks/Makefile.apk
 export VENDOR ?= helm
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export AUTO_UPDATE_ENABLED = false
+export APKBUILD_DEPENDS += dpkg
 export APKBUILD_INSTALL_SCRIPTS = $(PACKAGE_NAME).post-install $(PACKAGE_NAME).post-deinstall
 export INSTALL_DIR = /usr/share/${MASTER_PACKAGE_NAME}/${MAJOR_VERSION}/bin
 


### PR DESCRIPTION
## what
Add missing dependency for `helm`, `helm2`, and `helm3` packages

## why
Install can break without this dependency

