### PR TITLE
fix fetching strategy for vault and consul versions

### DIFF
--- a/vendor/consul/Makefile
+++ b/vendor/consul/Makefile
@@ -2,6 +2,9 @@
 include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk
 
+CURRENT_VERSION: QUERY=first(.[] | .name)
+CURRENT_VERSION: API=tags
+
 export VENDOR ?= hashicorp
 export PACKAGE_NAME ?= consul
 export DOWNLOAD_URL ?= https://releases.hashicorp.com/$(PACKAGE_NAME)/$(PACKAGE_VERSION)/$(PACKAGE_NAME)_$(PACKAGE_VERSION)_$(OS)_$(ARCH).zip

--- a/vendor/vault/Makefile
+++ b/vendor/vault/Makefile
@@ -1,11 +1,17 @@
 ## Package - vault
+export GITHUB_VERSION := $(shell cat VERSION)
+export PACKAGE_VERSION := $(shell echo ${GITHUB_VERSION} | sed -E 's/\-beta([0-9]+)/b\1/')
+
 include ../../tasks/Makefile.package
 include ../../tasks/Makefile.apk
 
 export VENDOR ?= hashicorp
 export PACKAGE_NAME ?= vault
-export DOWNLOAD_URL ?= https://releases.hashicorp.com/$(PACKAGE_NAME)/$(PACKAGE_VERSION)/$(PACKAGE_NAME)_$(PACKAGE_VERSION)_$(OS)_$(ARCH).zip
+export DOWNLOAD_URL ?= https://releases.hashicorp.com/$(PACKAGE_NAME)/$(GITHUB_VERSION)/$(PACKAGE_NAME)_$(GITHUB_VERSION)_$(OS)_$(ARCH).zip
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
+
+CURRENT_VERSION: QUERY=first(.[] | .name)
+CURRENT_VERSION: API=tags
 
 install:
 	$(call download_zip)


### PR DESCRIPTION
## what
* `vault` and `consul` fetch latest versions by tags

## why
* they don't have `releases` but only tags