### PR TITLE
sentinel version update fix

### DIFF
--- a/vendor/sentinel/Makefile
+++ b/vendor/sentinel/Makefile
@@ -11,6 +11,18 @@ export PACKAGE_NAME ?= sentinel
 export DOWNLOAD_URL ?= https://releases.hashicorp.com/$(PACKAGE_NAME)/$(PACKAGE_VERSION)/$(PACKAGE_NAME)_$(PACKAGE_VERSION)_$(OS)_$(ARCH).zip
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
+VERSION:
+	@version=$$(curl -s "https://releases.hashicorp.com/$(PACKAGE_NAME)/" | sed -nE 's/.*\<a\shref=\"\/sentinel\/(\d+\.\d+\.\d+)\/.*/\1/pi' | head -n 1); \
+	if [ $$? -ne 0 ]; then \
+		exit 1; \
+	fi; \
+	if [ "$${version}" == "null" -o "$${version}" == "" ]; then \
+		echo "ERROR: failed to obtain current version for $(VENDOR)/$(PACKAGE_REPO_NAME)"; \
+		exit 1; \
+	else \
+		echo "$${version}" | tee VERSION; \
+	fi
+
 CURRENT_VERSION::
 	@local_version=$$(cat VERSION || echo 0); \
 	current_version=$$(curl -s "https://releases.hashicorp.com/$(PACKAGE_NAME)/" | sed -nE 's/.*\<a\shref=\"\/sentinel\/(\d+\.\d+\.\d+)\/.*/\1/pi' | head -n 1); \


### PR DESCRIPTION
## what
* custom `sentinel` version check implemented

## why
* hashicorp `sentinel` doesn't have github repo/releases available. So we have to parse `https://releases.hashicorp.com/sentinel/` page
* closes #339 

## references
* `sentinel` releases page: https://releases.hashicorp.com/sentinel/
