### PR TITLE
sentinel auto update script fix

### DIFF
--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -150,12 +150,13 @@ auto-update:
 # Update the VERSION file only if it would change, to avoid triggering unnecessary builds
 CURRENT_VERSION: API=releases/latest
 CURRENT_VERSION: QUERY=.tag_name
-CURRENT_VERSION::
+CURRENT_VERSION:
 	@local_version=$$(cat VERSION || echo 0); \
 	current_version=$$(env PATH='$(PATH)' github-repo-metadata $(VENDOR) $(PACKAGE_REPO_NAME) '$(API)' '$(QUERY)' | sed 's/^v//'); \
 	if [ $$? -ne 0 ]; then \
 		exit 1; \
 	elif [ "$${current_version}" == "null" -o -z "$${current_version}" ]; then \
+		echo "I am here 111"; \
 		echo "ERROR: failed to obtain current version for $(VENDOR)/$(PACKAGE_REPO_NAME) (got: $${current_version})"; \
 		exit 1; \
 	elif [ "$${local_version}" != "$${current_version}" ]; then \

--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -156,7 +156,6 @@ CURRENT_VERSION:
 	if [ $$? -ne 0 ]; then \
 		exit 1; \
 	elif [ "$${current_version}" == "null" -o -z "$${current_version}" ]; then \
-		echo "I am here 111"; \
 		echo "ERROR: failed to obtain current version for $(VENDOR)/$(PACKAGE_REPO_NAME) (got: $${current_version})"; \
 		exit 1; \
 	elif [ "$${local_version}" != "$${current_version}" ]; then \

--- a/vendor/sentinel/Makefile
+++ b/vendor/sentinel/Makefile
@@ -23,7 +23,7 @@ VERSION:
 		echo "$${version}" | tee VERSION; \
 	fi
 
-CURRENT_VERSION::
+CURRENT_VERSION:
 	@local_version=$$(cat VERSION || echo 0); \
 	current_version=$$(curl -s "https://releases.hashicorp.com/$(PACKAGE_NAME)/" | sed -nE 's/.*\<a\shref=\"\/sentinel\/(\d+\.\d+\.\d+)\/.*/\1/pi' | head -n 1); \
 	if [ $$? -ne 0 ]; then \


### PR DESCRIPTION
## what
* custom `sentinel` version check implemented

## why
* hashicorp `sentinel` doesn't have github repo/releases available. So we have to parse `https://releases.hashicorp.com/sentinel/` page
* closes #339 

## references
* `sentinel` releases page: https://releases.hashicorp.com/sentinel/
