### PR TITLE
Support Any Version of Alpine Linux

### DIFF
--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/apkbuild.yml
+++ b/.github/workflows/apkbuild.yml
@@ -18,11 +18,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1` 
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     steps:
       - name: "Checkout source code at current commit"
         uses: actions/checkout@v2
@@ -37,10 +33,3 @@ jobs:
           registry: registry-1.docker.io
           tag_with_ref: true
           tag_with_sha: true
-      - name: "Build alpine packages"
-        uses: docker://cloudposse/packages-apkbuild:${{matrix.alpine}}
-        with:
-          args: "sh -c 'make -C /packages/vendor/terraform build'"
-        env:
-          APK_PACKAGES_PATH: /packages/artifacts/${{matrix.alpine}}
-

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-okta.yml
+++ b/.github/workflows/aws-okta.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-okta.yml
+++ b/.github/workflows/aws-okta.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-okta.yml
+++ b/.github/workflows/aws-okta.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-okta.yml
+++ b/.github/workflows/aws-okta.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cloudposse-atlantis.yml
+++ b/.github/workflows/cloudposse-atlantis.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cloudposse-atlantis.yml
+++ b/.github/workflows/cloudposse-atlantis.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cloudposse-atlantis.yml
+++ b/.github/workflows/cloudposse-atlantis.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/cloudposse-atlantis.yml
+++ b/.github/workflows/cloudposse-atlantis.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/duffle.yml
+++ b/.github/workflows/duffle.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/duffle.yml
+++ b/.github/workflows/duffle.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/duffle.yml
+++ b/.github/workflows/duffle.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/duffle.yml
+++ b/.github/workflows/duffle.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fargate.yml
+++ b/.github/workflows/fargate.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fargate.yml
+++ b/.github/workflows/fargate.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fargate.yml
+++ b/.github/workflows/fargate.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fargate.yml
+++ b/.github/workflows/fargate.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jq.yml
+++ b/.github/workflows/jq.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jq.yml
+++ b/.github/workflows/jq.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jq.yml
+++ b/.github/workflows/jq.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jq.yml
+++ b/.github/workflows/jq.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kops-1.12.yml
+++ b/.github/workflows/kops-1.12.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kops-1.12.yml
+++ b/.github/workflows/kops-1.12.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kops-1.12.yml
+++ b/.github/workflows/kops-1.12.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kops-1.12.yml
+++ b/.github/workflows/kops-1.12.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -97,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/scenery.yml
+++ b/.github/workflows/scenery.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/scenery.yml
+++ b/.github/workflows/scenery.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/scenery.yml
+++ b/.github/workflows/scenery.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/scenery.yml
+++ b/.github/workflows/scenery.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/tfenv.yml
+++ b/.github/workflows/tfenv.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/tfenv.yml
+++ b/.github/workflows/tfenv.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/tfenv.yml
+++ b/.github/workflows/tfenv.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/tfenv.yml
+++ b/.github/workflows/tfenv.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/tfmask.yml
+++ b/.github/workflows/tfmask.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/tfmask.yml
+++ b/.github/workflows/tfmask.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/tfmask.yml
+++ b/.github/workflows/tfmask.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/tfmask.yml
+++ b/.github/workflows/tfmask.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
+          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         # These versions must be strings. E.g. Otherwise `3.10` -> `3.1`
         alpine:
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
+          - '3.12'
     env:
       APK_KEY_RSA: "${{ secrets.APK_KEY_RSA }}"
       APK_PACKAGES_PATH: ${{github.workspace}}/artifacts/${{matrix.alpine}}
@@ -98,7 +94,7 @@ jobs:
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu)
-          release: 'v${{matrix.alpine}}'                    # Your Distribution Release (i.e xenial, buster)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than more version
           republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -95,6 +95,6 @@ jobs:
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
           distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
           release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
-          republish: 'true'                                 # Needed if version is not changilg
+          republish: 'true'                                 # Needed if version is not changing
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -93,8 +93,8 @@ jobs:
           format: 'alpine'
           owner: '${{steps.repo.outputs.org}}'              # Your Cloudsmith account name or org name (namespace)
           repo: 'packages'                                  # Your Cloudsmith Repository name (slug)
-          distro: 'alpine'                                  # Your Distribution  (i.e Debian, Ubuntu, Alpine)
-          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of Alpine Linux
-          republish: 'true'                                 # Needed if version is not changing
+          distro: 'alpine'                                  # Your Distribution  (i.e debian, ubuntu, alpine)
+          release: 'any-version'                            # Use "any-version" if your package is compatible with more than one version of alpine linux
+          republish: 'true'                                 # Needed if version is not changilg
           file: '${{steps.artifact.outputs.path}}'          # Package filename (including path)
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM cfssl/cfssl:1.3.2 as cfssl
 
 # Install remaining packages
-FROM alpine:3.11.6
+FROM alpine:3.12
 ENV INSTALL_PATH=/packages/bin
 ENV PATH=${INSTALL_PATH}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN mkdir -p ${INSTALL_PATH}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export README_DEPS ?= .github/auto-label.yml docs/badges.md workflows
 
 export DIST_CMD ?= cp -a
 export DIST_PATH ?= /dist
-export ALPINE_VERSION ?= 3.11
+export ALPINE_VERSION ?= 3.12
 
 SHELL := /bin/bash
 

--- a/apk/Dockerfile-3.12
+++ b/apk/Dockerfile-3.12
@@ -1,0 +1,11 @@
+FROM alpine:3.11
+
+# Install the cloudposse alpine repository
+ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/
+RUN echo "https://apk.cloudposse.com/3.12/vendor" >> /etc/apk/repositories
+RUN echo "https://alpine.global.ssl.fastly.net/alpine/edge/testing" >> /etc/apk/repositories
+RUN echo "https://alpine.global.ssl.fastly.net/alpine/edge/community" >> /etc/apk/repositories
+
+RUN apk update
+RUN apk add make curl alpine-sdk shadow bash jq
+RUN echo "auth       sufficient   pam_shells.so" > /etc/pam.d/chsh

--- a/apk/Dockerfile-3.12
+++ b/apk/Dockerfile-3.12
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.12
 
 # Install the cloudposse alpine repository
 ADD https://apk.cloudposse.com/ops@cloudposse.com.rsa.pub /etc/apk/keys/

--- a/apk/Dockerfile-3.12
+++ b/apk/Dockerfile-3.12
@@ -7,5 +7,5 @@ RUN echo "https://alpine.global.ssl.fastly.net/alpine/edge/testing" >> /etc/apk/
 RUN echo "https://alpine.global.ssl.fastly.net/alpine/edge/community" >> /etc/apk/repositories
 
 RUN apk update
-RUN apk add make curl alpine-sdk shadow bash jq
+RUN apk add make curl alpine-sdk shadow bash jq sudo
 RUN echo "auth       sufficient   pam_shells.so" > /etc/pam.d/chsh

--- a/vendor/github-status-updater/Makefile
+++ b/vendor/github-status-updater/Makefile
@@ -11,4 +11,4 @@ install:
 	$(call download_binary)
 
 test:
-	($(PACKAGE_EXE) || true) 2>&1 | grep required
+	($(PACKAGE_EXE) --help || true) 2>&1 | grep "Usage of github-status-updater"


### PR DESCRIPTION
## what
* Drop old builds, rely instead on cloudsmith's `any-version` feature

## why
* GitHub cancels builds if we queue up more than 500 at a time
* This is much, much more performant 
* We'll be able to always support the latest OS release

## references
- https://help.cloudsmith.io/docs/alpine-repository#upload-via-the-cloudsmith-cli


