### PR TITLE
Only run PR process if version changes

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - "check-success~=.*alpine.*"
       - "check-success~=.*debian.*"
-      - "check-success~=.*docker.*"
+      - "check-success~=.*build-and-push.*"
       - "base=master"
       - "author=cloudpossebot"
       - "head~=auto-update/.*"
@@ -16,7 +16,7 @@ pull_request_rules:
     conditions:
       - "check-success~=.*alpine.*"
       - "check-success~=.*debian.*"
-      - "check-success~=.*docker.*"
+      - "check-success~=.*build-and-push.*"
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "#commented-reviews-by=0"

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/%PACKAGE_NAME% info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/amtool info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/argocd info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/assume-role info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/atlantis info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/awless info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/aws-iam-authenticator info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/aws-okta.yml
+++ b/.github/workflows/aws-okta.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/aws-okta info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/aws-okta.yml
+++ b/.github/workflows/aws-okta.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/aws-vault info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/cfssl info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/cfssljson info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/chamber info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/cli53 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/cloudflared info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/cloudposse-atlantis.yml
+++ b/.github/workflows/cloudposse-atlantis.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/cloudposse-atlantis info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/cloudposse-atlantis.yml
+++ b/.github/workflows/cloudposse-atlantis.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/codefresh info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/conftest info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/consul info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/ctop info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/direnv info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/doctl info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/duffle.yml
+++ b/.github/workflows/duffle.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/duffle.yml
+++ b/.github/workflows/duffle.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/duffle info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/emailcli info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/fargate.yml
+++ b/.github/workflows/fargate.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/fargate info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/fargate.yml
+++ b/.github/workflows/fargate.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/fetch info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/figurine info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/fzf info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/gh info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/ghr info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/github-commenter info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/github-release info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/github-status-updater info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/gitleaks info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/gomplate info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/gonsul info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/goofys info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/gosu info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/gotop info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/helm info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/helm2 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/helm3 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/helmfile info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/htmltest info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/hugo info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/jp info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/jq.yml
+++ b/.github/workflows/jq.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/jq info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/jq.yml
+++ b/.github/workflows/jq.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/json2hcl info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/jx info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/k3d info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/k6 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/k9s info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/katafygio info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kfctl info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kind info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kops-1.12.yml
+++ b/.github/workflows/kops-1.12.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kops-1.12 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kops-1.12.yml
+++ b/.github/workflows/kops-1.12.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kops info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/krew info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubecron info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectl-1.13 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectl-1.14 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectl-1.15 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectl-1.16 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectl-1.17 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectl-1.18 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectl-1.19 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectl info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubectx info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubens info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/kubeval info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/lazydocker info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/lectl info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/minikube info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/misspell info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/nomad info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/nomad.yml
+++ b/.github/workflows/nomad.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/opa info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/pack info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/packer info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/pandoc info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/pgmetrics info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/pluto info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/popeye info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/promtool info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/rakkess info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/rancher info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/rbac-lookup info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/retry info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/saml2aws info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/scenery.yml
+++ b/.github/workflows/scenery.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/scenery.yml
+++ b/.github/workflows/scenery.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/scenery info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/sentinel info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/sentry-cli info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/shellcheck info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/shfmt info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/slack-notifier info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/sops info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/stern info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/sudosh info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/teleport info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terraform-0.11 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terraform-0.12 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terraform-0.13 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terraform-docs info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terraform info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terraform_0.11 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terraform_0.12 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terraform_0.13 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terragrunt info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/terrahelp info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/tfenv.yml
+++ b/.github/workflows/tfenv.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/tfenv.yml
+++ b/.github/workflows/tfenv.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/tfenv info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/tfmask.yml
+++ b/.github/workflows/tfmask.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/tfmask.yml
+++ b/.github/workflows/tfmask.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/tfmask info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/thanos info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/trivy info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/variant info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/variant2 info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/vault info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/venona info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/vert info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -34,6 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get current package information
+        shell: bash
+        id: current
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make -C vendor/yq info/github
+
       - name: Update packages
         shell: bash
         id: update
@@ -48,6 +57,7 @@ jobs:
 
       - name: Create Pull Request
         uses: cloudposse/actions/github/create-pull-request@0.20.0
+        if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
           commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}
-          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
+          commit-message: Update ${{ steps.update.outputs.package_name }} to ${{ steps.current.outputs.package_version }} → ${{ steps.update.outputs.package_version }}
           title: Update ${{ steps.update.outputs.package_name }} to ${{ steps.update.outputs.package_version }}
           body: |-
             ## what


### PR DESCRIPTION
## what
* Get the current version before fetching the latest version
* Only run the PR process if the versions do not match

## why
* Avoid readme updates being falsely associated with package updates
