### PR TITLE
Validate Codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@ tasks/*             @cloudposse/admins
 
 # Of course, admins must approve changes to CODEOWNERS itself
 .github/CODEOWNERS  @cloudposse/admins
+.github/workflows/validate-codeowners.yml @cloudposse/admins
 
 # Cloud Posse Engineering can update individual package Makefiles
 vendor/*/Makefile   @cloudposse/engineering

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,0 +1,18 @@
+name: Validate Codeowners
+on:
+  pull_request:
+    paths:
+    - '**/CODEOWNERS'
+    - '.github/workflows/validate-codeowners.yml'
+
+jobs:
+  validate-codeowners:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout source code at current commit"
+      uses: actions/checkout@v2
+    - uses: mszostok/codeowners-validator@v0.5.0
+      with:
+        checks: "syntax,owners,duppatterns"
+        # GitHub access token is required only if the `owners` check is enabled
+        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"


### PR DESCRIPTION
## what
- Install workflow to validate `CODEOWNERS` file

## why
- An invalid `CODEOWNERS` file disables all protections, so it is important we do not let one slip through
