### PR TITLE
Fix pre-release versions for deb and rpm

### DIFF
--- a/rpm/Dockerfile.centos8
+++ b/rpm/Dockerfile.centos8
@@ -3,7 +3,7 @@ FROM centos:centos8
 ENV LC_ALL=C.UTF-8
 ENV PS1="(rpm) \w \$ "
 
-RUN yum clean all && yum -y install ruby-devel gcc make rpm-build rubygems git zip bzip2 jq
+RUN yum clean all && yum -y install ruby-devel gcc make rpm-build rubygems git zip bzip2 jq which
 # install sudo, needed by package sudosh, and protected, so it is nearly impossible to remove
 RUN yum -y install sudo
 

--- a/tasks/Makefile.deb
+++ b/tasks/Makefile.deb
@@ -1,9 +1,11 @@
 PACKAGES_PATH ?= .
 DEB_PACKAGES_PATH ?= $(PACKAGES_PATH)
+# Debian sorts 1.0.0-rc1 as later than 1.0.0, but using tilde preserves semver ordering in most cases
+DEB_PACKAGE_VERSION = $(subst -,~,$(PACKAGE_VERSION))
 # By convention, the first release of a Debian package is 1, not zero
 DEB_PACKAGE_RELEASE = $(shell echo $$(($(PACKAGE_RELEASE) + 1)))
 # Package managers require that every package file have a unique name.
-DEB_PACKAGE ?= $(DEB_PACKAGES_PATH)/$(PACKAGE_NAME)_$(PACKAGE_VERSION)-$(DEB_PACKAGE_RELEASE)_$(ARCH).deb
+DEB_PACKAGE ?= $(DEB_PACKAGES_PATH)/$(PACKAGE_NAME)_$(DEB_PACKAGE_VERSION)-$(DEB_PACKAGE_RELEASE)_$(ARCH).deb
 DEB_MAINTAINER ?= Cloud Posse <packages@cloudposse.com>
 DEB_FPM_EXTRA_ARGS ?=
 DEB_FPM_EXTRA_FILES ?=
@@ -19,7 +21,7 @@ $(DEB_PACKAGE): DEB_FPM_EXTRA_ARGS += $(if $(wildcard $(PACKAGE_NAME).post-deins
 $(DEB_PACKAGE): $(DEB_TMP_DIR)/$(PACKAGE_NAME)
 	mkdir -p $(DEB_PACKAGES_PATH)
 	[ -z "$(DEB_FPM_EXTRA_FILES)" ] || cp -a $(DEB_FPM_EXTRA_FILES) $(DEB_TMP_DIR)
-	set -x; fpm --force -t deb --maintainer '$(DEB_MAINTAINER)' -s dir -a $(DIST_ARCH) -n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) --iteration $(DEB_PACKAGE_RELEASE) -C $(DEB_TMP_DIR) --prefix $${INSTALL_DIR:-/usr/bin} --deb-no-default-config-files $(DEB_FPM_EXTRA_ARGS) --package $@ .
+	set -x; fpm --force -t deb --maintainer '$(DEB_MAINTAINER)' -s dir -a $(DIST_ARCH) -n $(PACKAGE_NAME) -v $(DEB_PACKAGE_VERSION) --iteration $(DEB_PACKAGE_RELEASE) -C $(DEB_TMP_DIR) --prefix $${INSTALL_DIR:-/usr/bin} --deb-no-default-config-files $(DEB_FPM_EXTRA_ARGS) --package $@ .
 	@echo "Testing installation of $@"
 	apt-get install -y $@
 	$(MAKE) test

--- a/tasks/Makefile.rpm
+++ b/tasks/Makefile.rpm
@@ -1,9 +1,11 @@
 PACKAGES_PATH ?= .
 RPM_PACKAGES_PATH ?= $(PACKAGES_PATH)
+# RPM pacakges cannot have dashes, and using tilde preserves semver ordering in most cases
+RPM_PACKAGE_VERSION = $(subst -,~,$(PACKAGE_VERSION))
 # By convention, the first release of an RPM package is 1, not zero
 RPM_PACKAGE_RELEASE = $(shell echo $$(($(PACKAGE_RELEASE) + 1)))
 # Package managers require that every package file have a unique name.
-RPM_PACKAGE ?= $(RPM_PACKAGES_PATH)/$(PACKAGE_NAME)_$(PACKAGE_VERSION)-$(RPM_PACKAGE_RELEASE)_$(DIST_ARCH).rpm
+RPM_PACKAGE ?= $(RPM_PACKAGES_PATH)/$(PACKAGE_NAME)_$(RPM_PACKAGE_VERSION)-$(RPM_PACKAGE_RELEASE)_$(DIST_ARCH).rpm
 RPM_MAINTAINER ?= Cloud Posse <packages@cloudposse.com>
 RPM_FPM_EXTRA_ARGS ?=
 RPM_FPM_EXTRA_FILES ?=
@@ -28,7 +30,7 @@ $(RPM_PACKAGE): $(RPM_TMP_DIR)/$(PACKAGE_NAME)
 	mkdir -p $(RPM_PACKAGES_PATH)
 	[ -z "$(RPM_FPM_EXTRA_FILES)" ] || cp -a $(RPM_FPM_EXTRA_FILES) $(RPM_TMP_DIR)
 	[ -z "$(RPM_DEINSTALL)" ] || sed -i 's/\(update-alternatives .*\) --quiet/\1/' "$(RPM_TMP_DIR)/$(RPM_DEINSTALL)"
-	set -x; fpm --force -t rpm --maintainer '$(RPM_MAINTAINER)' -s dir -a $(DIST_ARCH) -n $(PACKAGE_NAME) -v $(PACKAGE_VERSION) --iteration $(RPM_PACKAGE_RELEASE) -C $(RPM_TMP_DIR) --prefix $${INSTALL_DIR:-/usr/bin} $(RPM_FPM_EXTRA_ARGS) --package $@ .
+	set -x; fpm --force -t rpm --maintainer '$(RPM_MAINTAINER)' -s dir -a $(DIST_ARCH) -n $(PACKAGE_NAME) -v $(RPM_PACKAGE_VERSION) --iteration $(RPM_PACKAGE_RELEASE) -C $(RPM_TMP_DIR) --prefix $${INSTALL_DIR:-/usr/bin} $(RPM_FPM_EXTRA_ARGS) --package $@ .
 	@echo "Testing installation of $@"
 	yum install -y --allowerasing -C $@
 	$(MAKE) test

--- a/vendor/teleport-5.0/Makefile
+++ b/vendor/teleport-5.0/Makefile
@@ -5,8 +5,7 @@ export MASTER_PACKAGE_NAME = teleport
 export MAJOR_VERSION = 5.0
 export PACKAGE_NAME = $(MASTER_PACKAGE_NAME)-$(MAJOR_VERSION)
 
-# At this point (Nov 2020) 5.0 is only in prerelease.
-export PACKAGE_PRERELEASE_ENABLED = true
+export PACKAGE_PRERELEASE_ENABLED = false
 
 # Starting with version 4.3, Teleport is not compatible with Alpine
 export PACKAGE_TYPES_DISABLED = apk

--- a/vendor/terraform-0.14/Makefile
+++ b/vendor/terraform-0.14/Makefile
@@ -4,7 +4,7 @@ export PACKAGE_REPO_NAME = terraform
 export PACKAGE_EXE = terraform
 export MASTER_PACKAGE_NAME = terraform
 export MAJOR_VERSION = 0.14
-export PACKAGE_PRERELEASE_ENABLED = true
+export PACKAGE_PRERELEASE_ENABLED = false
 export PACKAGE_NAME = $(MASTER_PACKAGE_NAME)-$(MAJOR_VERSION)
 
 include ../../tasks/Makefile.vendor_includes


### PR DESCRIPTION
## what
- Use `~` (tilde) instead of `-` dash in Debian and RPM package versions derived from pre-release "semver" versions
- Disable pre-release publication for `teleport-5.0` and `terraform-0.14`.

## why
- Debian and RPM packages are not sorted as in semver order. In particular 0.14.0 < 0.14.0-rc1 (deb) or 0.14.0_rc1 (rpm). Also RPM does not allow dashes. 
- `teleport-5.0` and `terraform-0.14` have reached general release

