### PR TITLE
Only publish docker images on "release"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
     - name: Prepare tags for Docker image
-      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
+      if: (github.event_name == 'release' && github.event.action == 'created')
       id: prepare
       run: |
         TAGS=${{ github.repository }}:sha-${GITHUB_SHA:0:7}
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
     - name: Login to DockerHub
-      if: (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository
+      if: (github.event_name == 'release' && github.event.action == 'created')
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -40,5 +40,5 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v2
       with:
-        push: ${{ (github.event_name == 'release' && github.event.action == 'created') || github.event.pull_request.head.repo.full_name == github.repository }}
+        push: ${{ (github.event_name == 'release' && github.event.action == 'created') }}
         tags: ${{ steps.prepare.outputs.tags }}


### PR DESCRIPTION
## what
- Only publish docker images when a new version of packages is officially released

## why
- Automatic updates come too frequently and in batches, causing `docker push` to fail and blocking automated release of packages
- Distribution of packages via Docker image is deprecated