### PR TITLE
Ensure INSTALL_PATH directory is readable by all users

### DIFF
--- a/tasks/Makefile.downloads
+++ b/tasks/Makefile.downloads
@@ -1,7 +1,7 @@
 # Macros to download a binary release from GitHub and install it
 # $(call github_download_binary_release,version,repo,asset)
 define download_binary
-	mkdir -p $(INSTALL_PATH)
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	$(CURL) -o $(INSTALL_PATH)/$(PACKAGE_EXE) $(DOWNLOAD_URL) && chmod +x $(INSTALL_PATH)/$(PACKAGE_EXE)
 endef
 
@@ -9,7 +9,7 @@ download/binary:
 	$(call download_binary)
 
 define download_binary_gz
-	mkdir -p $(INSTALL_PATH)
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	$(CURL) -o $(INSTALL_PATH)/$(PACKAGE_NAME).gz $(DOWNLOAD_URL)
 	gunzip -f -k -q $(INSTALL_PATH)/$(PACKAGE_NAME).gz
 	chmod +x $(INSTALL_PATH)/$(PACKAGE_EXE)
@@ -20,7 +20,7 @@ download/binary/gz:
 	$(call download_binary_gz)
 
 define download_binary_bz2
-	mkdir -p $(INSTALL_PATH)
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	$(CURL) -o $(INSTALL_PATH)/$(PACKAGE_NAME).bz2 $(DOWNLOAD_URL)
 	bzip2 -d -f -k -q $(INSTALL_PATH)/$(PACKAGE_NAME).bz2
 	chmod +x $(INSTALL_PATH)/$(PACKAGE_EXE)
@@ -31,6 +31,7 @@ download/binary/bz2:
 	$(call download_binary_bz2)
 
 define download_tarball
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 	mkdir -p $(TMP)/$(PACKAGE_NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C '$(TMP)/$(PACKAGE_NAME)'
@@ -43,6 +44,7 @@ download/tarball:
 	$(call download_tarball)
 
 define download_tar_bz2
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 	mkdir -p $(TMP)/$(PACKAGE_NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -jx -C $(TMP)/$(PACKAGE_NAME)
@@ -55,6 +57,7 @@ download/tar/bz2:
 	$(call download_tar_bz2)
 
 define download_tar_gz
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 	mkdir -p $(TMP)/$(PACKAGE_NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -zx -C $(TMP)/$(PACKAGE_NAME)
@@ -67,6 +70,7 @@ download/tar/gz:
 	$(call download_tar_gz)
 
 define download_tar_xz
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 	mkdir -p $(TMP)/$(PACKAGE_NAME)
 	$(CURL) -o - $(DOWNLOAD_URL) | tar -Jx -C $(TMP)/$(PACKAGE_NAME)
@@ -79,6 +83,7 @@ download/tar/xz:
 	$(call download_tar_xz)
 
 define download_zip
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 	mkdir -p $(TMP)/$(PACKAGE_NAME)
 	$(CURL) -L -o $(TMP)/$(PACKAGE_NAME)/$(PACKAGE_NAME).zip $(DOWNLOAD_URL)
@@ -92,6 +97,7 @@ download/zip:
 	$(call download_zip)
 
 define download_gz
+	mkdir -p -m a+rX $(INSTALL_PATH)
 	[ -n "$(TMP)" ] && [ -n "$(PACKAGE_NAME)" ] && rm -rf "$(TMP)/$(PACKAGE_NAME)"
 	mkdir -p $(TMP)/$(PACKAGE_NAME)
 	$(CURL) -L -o $(TMP)/$(PACKAGE_NAME)/$(PACKAGE_NAME).gz $(DOWNLOAD_URL)


### PR DESCRIPTION
## what

- Ensure the `INSTALL_PATH` directory can be read by all users.
- This is part of a larger effort to allow the creation of a `geodesic` user instead of starting geodesic shells as root.

## why

- Non-root users cannot read or execute the `.../bin` directory of the package and therefore cannot use the installed binary.

## Example

Debian package for `kubectl-1.16`

```shell
 √ . [nbo-identity] ~ ⨠ curl -sSL -o kubectl-1.16_1.16.15-1_amd64.deb https://dl.cloudsmith.io/public/cloudposse/packages/deb/debian/pool/any-version/main/k/ku/kubectl-1.16_1.16.15-1_amd64.deb

 √ . [nbo-identity] ~ ⨠ ls -al
total 12680
-rw-r--r-- 1 geodesic geodesic 12983848 May 25 12:16 kubectl-1.16_1.16.15-1_amd64.deb
 ⧉  my-custom-geodesic 
 √ . [nbo-identity] ~ ⨠ dpkg --contents kubectl-1.16_1.16.15-1_amd64.deb 
drwxr-xr-x 0/0               0 2021-05-04 07:16 ./
drwxr-xr-x 0/0               0 2021-05-04 07:16 ./usr/
drwxr-xr-x 0/0               0 2021-05-04 07:16 ./usr/share/
drwxr-xr-x 0/0               0 2021-05-04 07:16 ./usr/share/kubectl/
drwxr-xr-x 0/0               0 2021-05-04 07:16 ./usr/share/kubectl/1.16/
drwx------ 0/0               0 2021-05-04 07:16 ./usr/share/kubectl/1.16/bin/
-rwxr-xr-x 0/0        42967040 2021-05-04 07:16 ./usr/share/kubectl/1.16/bin/kubectl-1.16
drwxr-xr-x 0/0               0 2021-05-04 07:16 ./usr/share/doc/
drwxr-xr-x 0/0               0 2021-05-04 07:16 ./usr/share/doc/kubectl-1.16/
-rw-r--r-- 0/0             155 2021-05-04 07:16 ./usr/share/doc/kubectl-1.16/changelog.gz
```