### PR TITLE
Fix auto-update for Go Language libraries

### DIFF
--- a/tasks/Makefile.package
+++ b/tasks/Makefile.package
@@ -77,7 +77,7 @@ export PACKAGE_RELEASE ?= $(shell cat RELEASE 2>/dev/null)
 export PACKAGE_LICENSE ?= $(shell cat LICENSE 2>/dev/null)
 export PACKAGE_HOMEPAGE_URL ?= https://github.com/$(VENDOR)/$(PACKAGE)
 export PACKAGE_REPO_URL ?= https://github.com/$(VENDOR)/$(PACKAGE_REPO_NAME)
-export PACKAGE_GOLANG_NAME ?= github.com/$(VENDOR)/$(PACKAGE_NAME)
+export PACKAGE_GOLANG_NAME ?= github.com/$(VENDOR)/$(PACKAGE_REPO_NAME)
 
 export PACKAGE_VERSION_TARGET ?= RELEASE_VERSION
 

--- a/vendor/rainbow-text/Makefile
+++ b/vendor/rainbow-text/Makefile
@@ -5,6 +5,7 @@
 export VENDOR = arsham
 export PACKAGE_NAME = rainbow-text
 export PACKAGE_EXE = rainbow
+export PACKAGE_REPO_NAME = rainbow
 export DOWNLOAD_URL ?= $(PACKAGE_EXE)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 export APK_PACKAGE_VERSION := $(shell cat VERSION | sed s/\+.*//)


### PR DESCRIPTION
## what
- Fix auto-update for Go Language libraries

## why
- Auto-update was failing for `rainbow-text` because of confusion between `PACKAGE_NAME` and `PACKAGE_REPO_NAME`