### PR TITLE
Set correct permissions on install directory in Debian packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .build-harness
 build-harness
+/build-harness/
 .terraform
 *.tfstate
 *.tfstate.*

--- a/deb/Dockerfile.stable-slim
+++ b/deb/Dockerfile.stable-slim
@@ -1,5 +1,5 @@
 # Need to use version number so that it gets updated here and triggers a build
-FROM debian:10.9-slim
+FROM debian:10.10-slim
 
 ENV LC_ALL=C.UTF-8
 ENV PS1="(deb) \w \$ "
@@ -10,7 +10,7 @@ RUN apt-get update && \
 RUN gem install --no-document backports -v 3.15.0
 RUN gem install --no-document fpm
 
-ARG GO_INSTALL_VERSION=1.15.6
+ARG GO_INSTALL_VERSION=1.16.7
 
 # Install go
 RUN echo downloading go${GO_INSTALL_VERSION} && \

--- a/tasks/Makefile.deb
+++ b/tasks/Makefile.deb
@@ -20,8 +20,12 @@ $(DEB_PACKAGE): DEB_FPM_EXTRA_ARGS += $(if $(wildcard $(PACKAGE_NAME).post-insta
 $(DEB_PACKAGE): DEB_FPM_EXTRA_ARGS += $(if $(wildcard $(PACKAGE_NAME).post-deinstall),--after-remove $(PACKAGE_NAME).post-deinstall)
 $(DEB_PACKAGE): $(DEB_TMP_DIR)/$(PACKAGE_NAME)
 	mkdir -p $(DEB_PACKAGES_PATH)
+	# Directory created on install will have permissions copied from source directory, so set source dir perms
+	chmod 755 $(DEB_TMP_DIR)
 	[ -z "$(DEB_FPM_EXTRA_FILES)" ] || cp -a $(DEB_FPM_EXTRA_FILES) $(DEB_TMP_DIR)
-	set -x; fpm --force -t deb --maintainer '$(DEB_MAINTAINER)' -s dir -a $(DIST_ARCH) -n $(PACKAGE_NAME) -v $(DEB_PACKAGE_VERSION) --iteration $(DEB_PACKAGE_RELEASE) -C $(DEB_TMP_DIR) --prefix $${INSTALL_DIR:-/usr/bin} --deb-no-default-config-files $(DEB_FPM_EXTRA_ARGS) --package $@ .
+	set -x; fpm --force -t deb --maintainer '$(DEB_MAINTAINER)' -s dir -a $(DIST_ARCH) -n $(PACKAGE_NAME) \
+		-v $(DEB_PACKAGE_VERSION) --iteration $(DEB_PACKAGE_RELEASE) -C $(DEB_TMP_DIR) \
+		--prefix $${INSTALL_DIR:-/usr/bin} --deb-no-default-config-files $(DEB_FPM_EXTRA_ARGS) --package $@ .
 	@echo "Testing installation of $@"
 	apt-get install -y $@
 	$(MAKE) test


### PR DESCRIPTION
## what
- Set the permissions on the source directory for Debian packages, which sets the permissions for the installed directory when it is created by `dpkg`
- Upgrade Debian 10.9 -> 10.10
- Upgrade Go 1.15.6 -> 1.16.7

## why
- Closes #1622
- Keep up to date


