### PR TITLE
Create multi-arch (arm64, amd64) builders for RPM and Debian

### DIFF
--- a/.github/workflows/debbuild.yml
+++ b/.github/workflows/debbuild.yml
@@ -41,6 +41,8 @@ jobs:
           TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
         fi
         echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
@@ -53,5 +55,6 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.prepare.outputs.tags }}
         file: deb/Dockerfile.${{matrix.debian}}

--- a/.github/workflows/debbuild.yml
+++ b/.github/workflows/debbuild.yml
@@ -5,11 +5,13 @@ on:
       - master
     paths:
       - deb/**
+      - .github/workflows/debbuild.yml
 
   pull_request: 
     types: [opened, synchronize, reopened]
     paths:
       - deb/**
+      - .github/workflows/debbuild.yml
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,8 @@ jobs:
           TAGS="$TAGS,${{ github.repository }}:latest"
         fi
         echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
@@ -41,4 +43,5 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: ${{ (github.event_name == 'release' && github.event.action == 'created') }}
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.prepare.outputs.tags }}

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -41,6 +41,8 @@ jobs:
           TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
         fi
         echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to DockerHub
@@ -53,5 +55,6 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.prepare.outputs.tags }}
         file: rpm/Dockerfile.${{matrix.centos}}

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -5,11 +5,13 @@ on:
     - master
     paths:
     - rpm/**
+    - .github/workflows/rpmbuild.yml
 
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
     - rpm/**
+    - .github/workflows/rpmbuild.yml
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## what
- Create multi-arch (`linux/arm64`, `linux/amd64`) builders for RPM and Debian

## why
- Support native testing of `arm64` RPM and Debian packages. (No support planned for Alpine APK `arm64` packages.)

## references

- https://github.com/cloudposse/geodesic/issues/719

