### PR TITLE
make install/Makefile compatible with sh, not just bash

### DIFF
--- a/install/Makefile
+++ b/install/Makefile
@@ -6,11 +6,12 @@ all: $(shell find $(VENDOR_PATH) -maxdepth 1 -mindepth 1 -type d | xargs -n 1 ba
 
 ## Install a specific package
 %:
-	@if [[ -d $(VENDOR_PATH)/$@ ]]; then \
-  	  if [[ "$$(make -C $(VENDOR_PATH)/$@ info/package-enabled)" != "true" ]]; then \
+	# This needs to be compatible with /bin/sh and not just bash
+	@if [ -d $(VENDOR_PATH)/$@ ]; then \
+  	  if [ "$$(make -C $(VENDOR_PATH)/$@ info/package-enabled)" != "true" ]; then \
   	    echo "Package $@ no longer supported. Skipping"; \
   	    exit 0; \
-  	  elif [[ "$$(make -C $(VENDOR_PATH)/$@ info/arch-enabled)" != "true" ]]; then \
+  	  elif [ "$$(make -C $(VENDOR_PATH)/$@ info/arch-enabled)" != "true" ]; then \
   	    echo "Package $@ not supported on this CPU. Skipping"; \
   	    exit 0; \
   	  fi; \


### PR DESCRIPTION
## what 
- Make `install/Makefile` compatible with `sh`, not just `bash`

## why
- #3503 updated `install/Makefile` to take CPU architecture into account. However, the changes assumed that `make` was spawning `bash` shells. In the twisted path that has packages `auto-update` call `build-harness` to call `packages` to install `gomplate` to rebuild `README.md`, the `install/Makefile` spawns `sh` shells, not `bash` shells, so the Makefile recipe needs to be `sh` compatible.

