### PR TITLE
Remove extraneous text from tests

### DIFF
--- a/install/Makefile
+++ b/install/Makefile
@@ -6,12 +6,12 @@ all: $(shell find $(VENDOR_PATH) -maxdepth 1 -mindepth 1 -type d | xargs -n 1 ba
 
 ## Install a specific package
 %:
-	# This needs to be compatible with /bin/sh and not just bash
+	@# This needs to be compatible with /bin/sh and not just bash
 	@if [ -d $(VENDOR_PATH)/$@ ]; then \
-  	  if [ "$$(make -C $(VENDOR_PATH)/$@ info/package-enabled)" != "true" ]; then \
+  	  if [ "$$(make --no-print-directory --quiet --silent -C $(VENDOR_PATH)/$@ info/package-enabled)" != "true" ]; then \
   	    echo "Package $@ no longer supported. Skipping"; \
   	    exit 0; \
-  	  elif [ "$$(make -C $(VENDOR_PATH)/$@ info/arch-enabled)" != "true" ]; then \
+  	  elif [ "$$(make --no-print-directory --quiet --silent -C $(VENDOR_PATH)/$@ info/arch-enabled)" != "true" ]; then \
   	    echo "Package $@ not supported on this CPU. Skipping"; \
   	    exit 0; \
   	  fi; \


### PR DESCRIPTION
## what

- Continuation of #3505, remove progress information from `make` output so that the tests work correctly

## why

- Tests always returned false due to extra output from `make`, making them wrong and useless