### PR TITLE
Stronger rules for passing tests

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,13 @@ pull_request_rules:
       - "-check-failure~=.*alpine.*"
       - "-check-failure~=.*package.*"
       - "-check-failure~=.*matrix.*"
+      # We cannot wait for "all the checks" because at the start of a PR, there are no checks:
+      # checks get added dynamically. See https://docs.mergify.com/conditions/#validating-all-status-checks
+      # So we wait for one long check (build-and-push) and one late-starting check (package) to succeed,
+      # and then wait for any checks that have started to finish. That is as close to "all the checks" as we are going to get.
       - "check-success~=.*build-and-push.*"
+      - "check-success~=.*package.*"
+      - "#check-pending=0"
       - "#files<=6"
       - "base=master"
       - "author=cloudpossebot"
@@ -22,6 +28,8 @@ pull_request_rules:
       - "-check-failure~=.*package.*"
       - "-check-failure~=.*matrix.*"
       - "check-success~=.*build-and-push.*"
+      - "check-success~=.*package.*"
+      - "#check-pending=0"
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - "#commented-reviews-by=0"

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -45,7 +45,11 @@ env:
   %PACKAGE_NAME%_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-%PACKAGE_NAME%:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-%PACKAGE_NAME%:
+    needs: matrix-%PACKAGE_NAME%
+    if: github.event_name != 'schedule' && needs.matrix-%PACKAGE_NAME%.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-%PACKAGE_NAME%:
+    needs: matrix-%PACKAGE_NAME%
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-%PACKAGE_NAME%.outputs.package-enabled != 'false'
+      && needs.matrix-%PACKAGE_NAME%.outputs.package-matrix != '[]' && needs.matrix-%PACKAGE_NAME%.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-%PACKAGE_NAME%.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-%PACKAGE_NAME%.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/amazon-ecr-credential-helper.yml
+++ b/.github/workflows/amazon-ecr-credential-helper.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/amazon-ecr-credential-helper.yml
+++ b/.github/workflows/amazon-ecr-credential-helper.yml
@@ -45,7 +45,11 @@ env:
   amazon-ecr-credential-helper_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-amazon-ecr-credential-helper:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-amazon-ecr-credential-helper:
+    needs: matrix-amazon-ecr-credential-helper
+    if: github.event_name != 'schedule' && needs.matrix-amazon-ecr-credential-helper.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-amazon-ecr-credential-helper:
+    needs: matrix-amazon-ecr-credential-helper
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-amazon-ecr-credential-helper.outputs.package-enabled != 'false'
+      && needs.matrix-amazon-ecr-credential-helper.outputs.package-matrix != '[]' && needs.matrix-amazon-ecr-credential-helper.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-amazon-ecr-credential-helper.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-amazon-ecr-credential-helper.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -45,7 +45,11 @@ env:
   amtool_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-amtool:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-amtool:
+    needs: matrix-amtool
+    if: github.event_name != 'schedule' && needs.matrix-amtool.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-amtool:
+    needs: matrix-amtool
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-amtool.outputs.package-enabled != 'false'
+      && needs.matrix-amtool.outputs.package-matrix != '[]' && needs.matrix-amtool.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-amtool.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-amtool.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -45,7 +45,11 @@ env:
   argocd_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-argocd:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-argocd:
+    needs: matrix-argocd
+    if: github.event_name != 'schedule' && needs.matrix-argocd.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-argocd:
+    needs: matrix-argocd
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-argocd.outputs.package-enabled != 'false'
+      && needs.matrix-argocd.outputs.package-matrix != '[]' && needs.matrix-argocd.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-argocd.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-argocd.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -45,7 +45,11 @@ env:
   assume-role_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-assume-role:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-assume-role:
+    needs: matrix-assume-role
+    if: github.event_name != 'schedule' && needs.matrix-assume-role.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-assume-role:
+    needs: matrix-assume-role
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-assume-role.outputs.package-enabled != 'false'
+      && needs.matrix-assume-role.outputs.package-matrix != '[]' && needs.matrix-assume-role.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-assume-role.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-assume-role.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -45,7 +45,11 @@ env:
   atlantis_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-atlantis:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-atlantis:
+    needs: matrix-atlantis
+    if: github.event_name != 'schedule' && needs.matrix-atlantis.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-atlantis:
+    needs: matrix-atlantis
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-atlantis.outputs.package-enabled != 'false'
+      && needs.matrix-atlantis.outputs.package-matrix != '[]' && needs.matrix-atlantis.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-atlantis.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-atlantis.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -45,7 +45,11 @@ env:
   atmos_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-atmos:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-atmos:
+    needs: matrix-atmos
+    if: github.event_name != 'schedule' && needs.matrix-atmos.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-atmos:
+    needs: matrix-atmos
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-atmos.outputs.package-enabled != 'false'
+      && needs.matrix-atmos.outputs.package-matrix != '[]' && needs.matrix-atmos.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-atmos.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-atmos.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -45,7 +45,11 @@ env:
   awless_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-awless:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-awless:
+    needs: matrix-awless
+    if: github.event_name != 'schedule' && needs.matrix-awless.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-awless:
+    needs: matrix-awless
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-awless.outputs.package-enabled != 'false'
+      && needs.matrix-awless.outputs.package-matrix != '[]' && needs.matrix-awless.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-awless.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-awless.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/aws-copilot-cli.yml
+++ b/.github/workflows/aws-copilot-cli.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/aws-copilot-cli.yml
+++ b/.github/workflows/aws-copilot-cli.yml
@@ -45,7 +45,11 @@ env:
   aws-copilot-cli_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-aws-copilot-cli:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-aws-copilot-cli:
+    needs: matrix-aws-copilot-cli
+    if: github.event_name != 'schedule' && needs.matrix-aws-copilot-cli.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-aws-copilot-cli:
+    needs: matrix-aws-copilot-cli
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-aws-copilot-cli.outputs.package-enabled != 'false'
+      && needs.matrix-aws-copilot-cli.outputs.package-matrix != '[]' && needs.matrix-aws-copilot-cli.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-aws-copilot-cli.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-aws-copilot-cli.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -45,7 +45,11 @@ env:
   aws-iam-authenticator_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-aws-iam-authenticator:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-aws-iam-authenticator:
+    needs: matrix-aws-iam-authenticator
+    if: github.event_name != 'schedule' && needs.matrix-aws-iam-authenticator.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-aws-iam-authenticator:
+    needs: matrix-aws-iam-authenticator
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-aws-iam-authenticator.outputs.package-enabled != 'false'
+      && needs.matrix-aws-iam-authenticator.outputs.package-matrix != '[]' && needs.matrix-aws-iam-authenticator.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-aws-iam-authenticator.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-aws-iam-authenticator.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -45,7 +45,11 @@ env:
   aws-nuke_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-aws-nuke:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-aws-nuke:
+    needs: matrix-aws-nuke
+    if: github.event_name != 'schedule' && needs.matrix-aws-nuke.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-aws-nuke:
+    needs: matrix-aws-nuke
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-aws-nuke.outputs.package-enabled != 'false'
+      && needs.matrix-aws-nuke.outputs.package-matrix != '[]' && needs.matrix-aws-nuke.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-aws-nuke.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-aws-nuke.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -45,7 +45,11 @@ env:
   aws-vault_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-aws-vault:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-aws-vault:
+    needs: matrix-aws-vault
+    if: github.event_name != 'schedule' && needs.matrix-aws-vault.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-aws-vault:
+    needs: matrix-aws-vault
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-aws-vault.outputs.package-enabled != 'false'
+      && needs.matrix-aws-vault.outputs.package-matrix != '[]' && needs.matrix-aws-vault.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-aws-vault.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-aws-vault.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -45,7 +45,11 @@ env:
   cfssl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-cfssl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-cfssl:
+    needs: matrix-cfssl
+    if: github.event_name != 'schedule' && needs.matrix-cfssl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-cfssl:
+    needs: matrix-cfssl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-cfssl.outputs.package-enabled != 'false'
+      && needs.matrix-cfssl.outputs.package-matrix != '[]' && needs.matrix-cfssl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-cfssl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-cfssl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -45,7 +45,11 @@ env:
   cfssljson_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-cfssljson:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-cfssljson:
+    needs: matrix-cfssljson
+    if: github.event_name != 'schedule' && needs.matrix-cfssljson.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-cfssljson:
+    needs: matrix-cfssljson
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-cfssljson.outputs.package-enabled != 'false'
+      && needs.matrix-cfssljson.outputs.package-matrix != '[]' && needs.matrix-cfssljson.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-cfssljson.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-cfssljson.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -45,7 +45,11 @@ env:
   chamber_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-chamber:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-chamber:
+    needs: matrix-chamber
+    if: github.event_name != 'schedule' && needs.matrix-chamber.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-chamber:
+    needs: matrix-chamber
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-chamber.outputs.package-enabled != 'false'
+      && needs.matrix-chamber.outputs.package-matrix != '[]' && needs.matrix-chamber.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-chamber.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-chamber.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -45,7 +45,11 @@ env:
   cli53_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-cli53:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-cli53:
+    needs: matrix-cli53
+    if: github.event_name != 'schedule' && needs.matrix-cli53.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-cli53:
+    needs: matrix-cli53
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-cli53.outputs.package-enabled != 'false'
+      && needs.matrix-cli53.outputs.package-matrix != '[]' && needs.matrix-cli53.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-cli53.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-cli53.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -45,7 +45,11 @@ env:
   cloud-nuke_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-cloud-nuke:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-cloud-nuke:
+    needs: matrix-cloud-nuke
+    if: github.event_name != 'schedule' && needs.matrix-cloud-nuke.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-cloud-nuke:
+    needs: matrix-cloud-nuke
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-cloud-nuke.outputs.package-enabled != 'false'
+      && needs.matrix-cloud-nuke.outputs.package-matrix != '[]' && needs.matrix-cloud-nuke.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-cloud-nuke.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-cloud-nuke.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -45,7 +45,11 @@ env:
   cloudflared_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-cloudflared:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-cloudflared:
+    needs: matrix-cloudflared
+    if: github.event_name != 'schedule' && needs.matrix-cloudflared.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-cloudflared:
+    needs: matrix-cloudflared
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-cloudflared.outputs.package-enabled != 'false'
+      && needs.matrix-cloudflared.outputs.package-matrix != '[]' && needs.matrix-cloudflared.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-cloudflared.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-cloudflared.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -45,7 +45,11 @@ env:
   codefresh_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-codefresh:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-codefresh:
+    needs: matrix-codefresh
+    if: github.event_name != 'schedule' && needs.matrix-codefresh.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-codefresh:
+    needs: matrix-codefresh
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-codefresh.outputs.package-enabled != 'false'
+      && needs.matrix-codefresh.outputs.package-matrix != '[]' && needs.matrix-codefresh.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-codefresh.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-codefresh.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -45,7 +45,11 @@ env:
   conftest_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-conftest:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-conftest:
+    needs: matrix-conftest
+    if: github.event_name != 'schedule' && needs.matrix-conftest.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-conftest:
+    needs: matrix-conftest
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-conftest.outputs.package-enabled != 'false'
+      && needs.matrix-conftest.outputs.package-matrix != '[]' && needs.matrix-conftest.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-conftest.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-conftest.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -45,7 +45,11 @@ env:
   consul_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-consul:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-consul:
+    needs: matrix-consul
+    if: github.event_name != 'schedule' && needs.matrix-consul.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-consul:
+    needs: matrix-consul
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-consul.outputs.package-enabled != 'false'
+      && needs.matrix-consul.outputs.package-matrix != '[]' && needs.matrix-consul.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-consul.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-consul.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -45,7 +45,11 @@ env:
   ctop_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-ctop:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-ctop:
+    needs: matrix-ctop
+    if: github.event_name != 'schedule' && needs.matrix-ctop.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-ctop:
+    needs: matrix-ctop
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-ctop.outputs.package-enabled != 'false'
+      && needs.matrix-ctop.outputs.package-matrix != '[]' && needs.matrix-ctop.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-ctop.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-ctop.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -45,7 +45,11 @@ env:
   direnv_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-direnv:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-direnv:
+    needs: matrix-direnv
+    if: github.event_name != 'schedule' && needs.matrix-direnv.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-direnv:
+    needs: matrix-direnv
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-direnv.outputs.package-enabled != 'false'
+      && needs.matrix-direnv.outputs.package-matrix != '[]' && needs.matrix-direnv.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-direnv.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-direnv.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -45,7 +45,11 @@ env:
   doctl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-doctl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-doctl:
+    needs: matrix-doctl
+    if: github.event_name != 'schedule' && needs.matrix-doctl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-doctl:
+    needs: matrix-doctl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-doctl.outputs.package-enabled != 'false'
+      && needs.matrix-doctl.outputs.package-matrix != '[]' && needs.matrix-doctl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-doctl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-doctl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/ec2-instance-selector.yml
+++ b/.github/workflows/ec2-instance-selector.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/ec2-instance-selector.yml
+++ b/.github/workflows/ec2-instance-selector.yml
@@ -45,7 +45,11 @@ env:
   ec2-instance-selector_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-ec2-instance-selector:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-ec2-instance-selector:
+    needs: matrix-ec2-instance-selector
+    if: github.event_name != 'schedule' && needs.matrix-ec2-instance-selector.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-ec2-instance-selector:
+    needs: matrix-ec2-instance-selector
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-ec2-instance-selector.outputs.package-enabled != 'false'
+      && needs.matrix-ec2-instance-selector.outputs.package-matrix != '[]' && needs.matrix-ec2-instance-selector.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-ec2-instance-selector.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-ec2-instance-selector.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -45,7 +45,11 @@ env:
   emailcli_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-emailcli:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-emailcli:
+    needs: matrix-emailcli
+    if: github.event_name != 'schedule' && needs.matrix-emailcli.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-emailcli:
+    needs: matrix-emailcli
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-emailcli.outputs.package-enabled != 'false'
+      && needs.matrix-emailcli.outputs.package-matrix != '[]' && needs.matrix-emailcli.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-emailcli.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-emailcli.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/envcli.yml
+++ b/.github/workflows/envcli.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/envcli.yml
+++ b/.github/workflows/envcli.yml
@@ -45,7 +45,11 @@ env:
   envcli_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-envcli:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-envcli:
+    needs: matrix-envcli
+    if: github.event_name != 'schedule' && needs.matrix-envcli.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-envcli:
+    needs: matrix-envcli
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-envcli.outputs.package-enabled != 'false'
+      && needs.matrix-envcli.outputs.package-matrix != '[]' && needs.matrix-envcli.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-envcli.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-envcli.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -45,7 +45,11 @@ env:
   fetch_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-fetch:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-fetch:
+    needs: matrix-fetch
+    if: github.event_name != 'schedule' && needs.matrix-fetch.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-fetch:
+    needs: matrix-fetch
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-fetch.outputs.package-enabled != 'false'
+      && needs.matrix-fetch.outputs.package-matrix != '[]' && needs.matrix-fetch.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-fetch.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-fetch.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -45,7 +45,11 @@ env:
   figurine_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-figurine:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-figurine:
+    needs: matrix-figurine
+    if: github.event_name != 'schedule' && needs.matrix-figurine.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-figurine:
+    needs: matrix-figurine
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-figurine.outputs.package-enabled != 'false'
+      && needs.matrix-figurine.outputs.package-matrix != '[]' && needs.matrix-figurine.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-figurine.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-figurine.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -45,7 +45,11 @@ env:
   fzf_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-fzf:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-fzf:
+    needs: matrix-fzf
+    if: github.event_name != 'schedule' && needs.matrix-fzf.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-fzf:
+    needs: matrix-fzf
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-fzf.outputs.package-enabled != 'false'
+      && needs.matrix-fzf.outputs.package-matrix != '[]' && needs.matrix-fzf.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-fzf.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-fzf.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -45,7 +45,11 @@ env:
   gh_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-gh:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-gh:
+    needs: matrix-gh
+    if: github.event_name != 'schedule' && needs.matrix-gh.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-gh:
+    needs: matrix-gh
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-gh.outputs.package-enabled != 'false'
+      && needs.matrix-gh.outputs.package-matrix != '[]' && needs.matrix-gh.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-gh.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-gh.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -45,7 +45,11 @@ env:
   ghr_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-ghr:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-ghr:
+    needs: matrix-ghr
+    if: github.event_name != 'schedule' && needs.matrix-ghr.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-ghr:
+    needs: matrix-ghr
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-ghr.outputs.package-enabled != 'false'
+      && needs.matrix-ghr.outputs.package-matrix != '[]' && needs.matrix-ghr.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-ghr.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-ghr.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -45,7 +45,11 @@ env:
   github-commenter_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-github-commenter:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-github-commenter:
+    needs: matrix-github-commenter
+    if: github.event_name != 'schedule' && needs.matrix-github-commenter.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-github-commenter:
+    needs: matrix-github-commenter
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-github-commenter.outputs.package-enabled != 'false'
+      && needs.matrix-github-commenter.outputs.package-matrix != '[]' && needs.matrix-github-commenter.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-github-commenter.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-github-commenter.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -45,7 +45,11 @@ env:
   github-release_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-github-release:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-github-release:
+    needs: matrix-github-release
+    if: github.event_name != 'schedule' && needs.matrix-github-release.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-github-release:
+    needs: matrix-github-release
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-github-release.outputs.package-enabled != 'false'
+      && needs.matrix-github-release.outputs.package-matrix != '[]' && needs.matrix-github-release.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-github-release.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-github-release.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -45,7 +45,11 @@ env:
   github-status-updater_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-github-status-updater:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-github-status-updater:
+    needs: matrix-github-status-updater
+    if: github.event_name != 'schedule' && needs.matrix-github-status-updater.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-github-status-updater:
+    needs: matrix-github-status-updater
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-github-status-updater.outputs.package-enabled != 'false'
+      && needs.matrix-github-status-updater.outputs.package-matrix != '[]' && needs.matrix-github-status-updater.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-github-status-updater.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-github-status-updater.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -45,7 +45,11 @@ env:
   gitleaks_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-gitleaks:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-gitleaks:
+    needs: matrix-gitleaks
+    if: github.event_name != 'schedule' && needs.matrix-gitleaks.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-gitleaks:
+    needs: matrix-gitleaks
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-gitleaks.outputs.package-enabled != 'false'
+      && needs.matrix-gitleaks.outputs.package-matrix != '[]' && needs.matrix-gitleaks.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-gitleaks.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-gitleaks.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/go-jsonnet.yml
+++ b/.github/workflows/go-jsonnet.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/go-jsonnet.yml
+++ b/.github/workflows/go-jsonnet.yml
@@ -45,7 +45,11 @@ env:
   go-jsonnet_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-go-jsonnet:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-go-jsonnet:
+    needs: matrix-go-jsonnet
+    if: github.event_name != 'schedule' && needs.matrix-go-jsonnet.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-go-jsonnet:
+    needs: matrix-go-jsonnet
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-go-jsonnet.outputs.package-enabled != 'false'
+      && needs.matrix-go-jsonnet.outputs.package-matrix != '[]' && needs.matrix-go-jsonnet.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-go-jsonnet.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-go-jsonnet.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -45,7 +45,11 @@ env:
   gomplate_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-gomplate:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-gomplate:
+    needs: matrix-gomplate
+    if: github.event_name != 'schedule' && needs.matrix-gomplate.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-gomplate:
+    needs: matrix-gomplate
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-gomplate.outputs.package-enabled != 'false'
+      && needs.matrix-gomplate.outputs.package-matrix != '[]' && needs.matrix-gomplate.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-gomplate.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-gomplate.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -45,7 +45,11 @@ env:
   gonsul_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-gonsul:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-gonsul:
+    needs: matrix-gonsul
+    if: github.event_name != 'schedule' && needs.matrix-gonsul.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-gonsul:
+    needs: matrix-gonsul
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-gonsul.outputs.package-enabled != 'false'
+      && needs.matrix-gonsul.outputs.package-matrix != '[]' && needs.matrix-gonsul.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-gonsul.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-gonsul.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -45,7 +45,11 @@ env:
   goofys_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-goofys:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-goofys:
+    needs: matrix-goofys
+    if: github.event_name != 'schedule' && needs.matrix-goofys.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-goofys:
+    needs: matrix-goofys
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-goofys.outputs.package-enabled != 'false'
+      && needs.matrix-goofys.outputs.package-matrix != '[]' && needs.matrix-goofys.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-goofys.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-goofys.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -45,7 +45,11 @@ env:
   gosu_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-gosu:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-gosu:
+    needs: matrix-gosu
+    if: github.event_name != 'schedule' && needs.matrix-gosu.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-gosu:
+    needs: matrix-gosu
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-gosu.outputs.package-enabled != 'false'
+      && needs.matrix-gosu.outputs.package-matrix != '[]' && needs.matrix-gosu.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-gosu.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-gosu.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -45,7 +45,11 @@ env:
   gotop_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-gotop:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-gotop:
+    needs: matrix-gotop
+    if: github.event_name != 'schedule' && needs.matrix-gotop.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-gotop:
+    needs: matrix-gotop
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-gotop.outputs.package-enabled != 'false'
+      && needs.matrix-gotop.outputs.package-matrix != '[]' && needs.matrix-gotop.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-gotop.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-gotop.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/grpcurl.yml
+++ b/.github/workflows/grpcurl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/grpcurl.yml
+++ b/.github/workflows/grpcurl.yml
@@ -45,7 +45,11 @@ env:
   grpcurl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-grpcurl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-grpcurl:
+    needs: matrix-grpcurl
+    if: github.event_name != 'schedule' && needs.matrix-grpcurl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-grpcurl:
+    needs: matrix-grpcurl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-grpcurl.outputs.package-enabled != 'false'
+      && needs.matrix-grpcurl.outputs.package-matrix != '[]' && needs.matrix-grpcurl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-grpcurl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-grpcurl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/hcledit.yml
+++ b/.github/workflows/hcledit.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/hcledit.yml
+++ b/.github/workflows/hcledit.yml
@@ -45,7 +45,11 @@ env:
   hcledit_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-hcledit:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-hcledit:
+    needs: matrix-hcledit
+    if: github.event_name != 'schedule' && needs.matrix-hcledit.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-hcledit:
+    needs: matrix-hcledit
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-hcledit.outputs.package-enabled != 'false'
+      && needs.matrix-hcledit.outputs.package-matrix != '[]' && needs.matrix-hcledit.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-hcledit.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-hcledit.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -45,7 +45,11 @@ env:
   helm_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-helm:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-helm:
+    needs: matrix-helm
+    if: github.event_name != 'schedule' && needs.matrix-helm.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-helm:
+    needs: matrix-helm
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-helm.outputs.package-enabled != 'false'
+      && needs.matrix-helm.outputs.package-matrix != '[]' && needs.matrix-helm.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-helm.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-helm.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -45,7 +45,11 @@ env:
   helm2_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-helm2:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-helm2:
+    needs: matrix-helm2
+    if: github.event_name != 'schedule' && needs.matrix-helm2.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-helm2:
+    needs: matrix-helm2
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-helm2.outputs.package-enabled != 'false'
+      && needs.matrix-helm2.outputs.package-matrix != '[]' && needs.matrix-helm2.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-helm2.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-helm2.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -45,7 +45,11 @@ env:
   helm3_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-helm3:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-helm3:
+    needs: matrix-helm3
+    if: github.event_name != 'schedule' && needs.matrix-helm3.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-helm3:
+    needs: matrix-helm3
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-helm3.outputs.package-enabled != 'false'
+      && needs.matrix-helm3.outputs.package-matrix != '[]' && needs.matrix-helm3.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-helm3.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-helm3.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -45,7 +45,11 @@ env:
   helmfile_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-helmfile:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-helmfile:
+    needs: matrix-helmfile
+    if: github.event_name != 'schedule' && needs.matrix-helmfile.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-helmfile:
+    needs: matrix-helmfile
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-helmfile.outputs.package-enabled != 'false'
+      && needs.matrix-helmfile.outputs.package-matrix != '[]' && needs.matrix-helmfile.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-helmfile.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-helmfile.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -45,7 +45,11 @@ env:
   htmltest_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-htmltest:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-htmltest:
+    needs: matrix-htmltest
+    if: github.event_name != 'schedule' && needs.matrix-htmltest.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-htmltest:
+    needs: matrix-htmltest
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-htmltest.outputs.package-enabled != 'false'
+      && needs.matrix-htmltest.outputs.package-matrix != '[]' && needs.matrix-htmltest.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-htmltest.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-htmltest.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -45,7 +45,11 @@ env:
   hugo_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-hugo:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-hugo:
+    needs: matrix-hugo
+    if: github.event_name != 'schedule' && needs.matrix-hugo.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-hugo:
+    needs: matrix-hugo
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-hugo.outputs.package-enabled != 'false'
+      && needs.matrix-hugo.outputs.package-matrix != '[]' && needs.matrix-hugo.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-hugo.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-hugo.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -45,7 +45,11 @@ env:
   infracost_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-infracost:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-infracost:
+    needs: matrix-infracost
+    if: github.event_name != 'schedule' && needs.matrix-infracost.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-infracost:
+    needs: matrix-infracost
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-infracost.outputs.package-enabled != 'false'
+      && needs.matrix-infracost.outputs.package-matrix != '[]' && needs.matrix-infracost.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-infracost.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-infracost.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -45,7 +45,11 @@ env:
   jp_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-jp:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-jp:
+    needs: matrix-jp
+    if: github.event_name != 'schedule' && needs.matrix-jp.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-jp:
+    needs: matrix-jp
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-jp.outputs.package-enabled != 'false'
+      && needs.matrix-jp.outputs.package-matrix != '[]' && needs.matrix-jp.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-jp.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-jp.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -45,7 +45,11 @@ env:
   json2hcl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-json2hcl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-json2hcl:
+    needs: matrix-json2hcl
+    if: github.event_name != 'schedule' && needs.matrix-json2hcl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-json2hcl:
+    needs: matrix-json2hcl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-json2hcl.outputs.package-enabled != 'false'
+      && needs.matrix-json2hcl.outputs.package-matrix != '[]' && needs.matrix-json2hcl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-json2hcl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-json2hcl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -45,7 +45,11 @@ env:
   jx_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-jx:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-jx:
+    needs: matrix-jx
+    if: github.event_name != 'schedule' && needs.matrix-jx.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-jx:
+    needs: matrix-jx
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-jx.outputs.package-enabled != 'false'
+      && needs.matrix-jx.outputs.package-matrix != '[]' && needs.matrix-jx.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-jx.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-jx.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -45,7 +45,11 @@ env:
   k3d_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-k3d:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-k3d:
+    needs: matrix-k3d
+    if: github.event_name != 'schedule' && needs.matrix-k3d.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-k3d:
+    needs: matrix-k3d
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-k3d.outputs.package-enabled != 'false'
+      && needs.matrix-k3d.outputs.package-matrix != '[]' && needs.matrix-k3d.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-k3d.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-k3d.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -45,7 +45,11 @@ env:
   k6_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-k6:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-k6:
+    needs: matrix-k6
+    if: github.event_name != 'schedule' && needs.matrix-k6.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-k6:
+    needs: matrix-k6
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-k6.outputs.package-enabled != 'false'
+      && needs.matrix-k6.outputs.package-matrix != '[]' && needs.matrix-k6.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-k6.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-k6.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -45,7 +45,11 @@ env:
   k9s_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-k9s:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-k9s:
+    needs: matrix-k9s
+    if: github.event_name != 'schedule' && needs.matrix-k9s.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-k9s:
+    needs: matrix-k9s
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-k9s.outputs.package-enabled != 'false'
+      && needs.matrix-k9s.outputs.package-matrix != '[]' && needs.matrix-k9s.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-k9s.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-k9s.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -45,7 +45,11 @@ env:
   katafygio_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-katafygio:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-katafygio:
+    needs: matrix-katafygio
+    if: github.event_name != 'schedule' && needs.matrix-katafygio.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-katafygio:
+    needs: matrix-katafygio
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-katafygio.outputs.package-enabled != 'false'
+      && needs.matrix-katafygio.outputs.package-matrix != '[]' && needs.matrix-katafygio.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-katafygio.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-katafygio.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -45,7 +45,11 @@ env:
   kfctl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kfctl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kfctl:
+    needs: matrix-kfctl
+    if: github.event_name != 'schedule' && needs.matrix-kfctl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kfctl:
+    needs: matrix-kfctl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kfctl.outputs.package-enabled != 'false'
+      && needs.matrix-kfctl.outputs.package-matrix != '[]' && needs.matrix-kfctl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kfctl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kfctl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -45,7 +45,11 @@ env:
   kind_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kind:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kind:
+    needs: matrix-kind
+    if: github.event_name != 'schedule' && needs.matrix-kind.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kind:
+    needs: matrix-kind
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kind.outputs.package-enabled != 'false'
+      && needs.matrix-kind.outputs.package-matrix != '[]' && needs.matrix-kind.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kind.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kind.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -45,7 +45,11 @@ env:
   kops_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kops:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kops:
+    needs: matrix-kops
+    if: github.event_name != 'schedule' && needs.matrix-kops.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kops:
+    needs: matrix-kops
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kops.outputs.package-enabled != 'false'
+      && needs.matrix-kops.outputs.package-matrix != '[]' && needs.matrix-kops.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kops.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kops.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -45,7 +45,11 @@ env:
   krew_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-krew:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-krew:
+    needs: matrix-krew
+    if: github.event_name != 'schedule' && needs.matrix-krew.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-krew:
+    needs: matrix-krew
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-krew.outputs.package-enabled != 'false'
+      && needs.matrix-krew.outputs.package-matrix != '[]' && needs.matrix-krew.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-krew.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-krew.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -45,7 +45,11 @@ env:
   kubecron_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubecron:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubecron:
+    needs: matrix-kubecron
+    if: github.event_name != 'schedule' && needs.matrix-kubecron.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubecron:
+    needs: matrix-kubecron
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubecron.outputs.package-enabled != 'false'
+      && needs.matrix-kubecron.outputs.package-matrix != '[]' && needs.matrix-kubecron.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubecron.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubecron.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.13_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.13:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.13:
+    needs: matrix-kubectl-1.13
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.13.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.13:
+    needs: matrix-kubectl-1.13
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.13.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.13.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.13.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.13.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.13.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.14_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.14:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.14:
+    needs: matrix-kubectl-1.14
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.14.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.14:
+    needs: matrix-kubectl-1.14
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.14.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.14.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.14.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.14.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.14.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.15_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.15:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.15:
+    needs: matrix-kubectl-1.15
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.15.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.15:
+    needs: matrix-kubectl-1.15
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.15.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.15.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.15.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.15.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.15.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.16_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.16:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.16:
+    needs: matrix-kubectl-1.16
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.16.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.16:
+    needs: matrix-kubectl-1.16
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.16.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.16.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.16.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.16.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.16.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.17_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.17:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.17:
+    needs: matrix-kubectl-1.17
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.17.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.17:
+    needs: matrix-kubectl-1.17
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.17.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.17.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.17.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.17.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.17.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.18_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.18:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.18:
+    needs: matrix-kubectl-1.18
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.18.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.18:
+    needs: matrix-kubectl-1.18
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.18.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.18.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.18.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.18.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.18.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.19_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.19:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.19:
+    needs: matrix-kubectl-1.19
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.19.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.19:
+    needs: matrix-kubectl-1.19
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.19.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.19.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.19.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.19.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.19.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.20.yml
+++ b/.github/workflows/kubectl-1.20.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.20.yml
+++ b/.github/workflows/kubectl-1.20.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.20_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.20:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.20:
+    needs: matrix-kubectl-1.20
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.20.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.20:
+    needs: matrix-kubectl-1.20
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.20.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.20.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.20.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.20.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.20.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.21.yml
+++ b/.github/workflows/kubectl-1.21.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.21.yml
+++ b/.github/workflows/kubectl-1.21.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.21_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.21:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.21:
+    needs: matrix-kubectl-1.21
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.21.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.21:
+    needs: matrix-kubectl-1.21
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.21.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.21.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.21.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.21.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.21.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.22.yml
+++ b/.github/workflows/kubectl-1.22.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.22.yml
+++ b/.github/workflows/kubectl-1.22.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.22_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.22:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.22:
+    needs: matrix-kubectl-1.22
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.22.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.22:
+    needs: matrix-kubectl-1.22
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.22.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.22.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.22.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.22.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.22.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.23.yml
+++ b/.github/workflows/kubectl-1.23.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.23.yml
+++ b/.github/workflows/kubectl-1.23.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.23_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.23:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.23:
+    needs: matrix-kubectl-1.23
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.23.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.23:
+    needs: matrix-kubectl-1.23
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.23.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.23.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.23.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.23.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.23.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.24.yml
+++ b/.github/workflows/kubectl-1.24.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.24.yml
+++ b/.github/workflows/kubectl-1.24.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.24_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.24:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.24:
+    needs: matrix-kubectl-1.24
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.24.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.24:
+    needs: matrix-kubectl-1.24
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.24.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.24.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.24.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.24.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.24.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.25.yml
+++ b/.github/workflows/kubectl-1.25.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.25.yml
+++ b/.github/workflows/kubectl-1.25.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.25_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.25:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.25:
+    needs: matrix-kubectl-1.25
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.25.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.25:
+    needs: matrix-kubectl-1.25
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.25.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.25.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.25.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.25.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.25.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl-1.26.yml
+++ b/.github/workflows/kubectl-1.26.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl-1.26.yml
+++ b/.github/workflows/kubectl-1.26.yml
@@ -45,7 +45,11 @@ env:
   kubectl-1.26_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl-1.26:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl-1.26:
+    needs: matrix-kubectl-1.26
+    if: github.event_name != 'schedule' && needs.matrix-kubectl-1.26.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl-1.26:
+    needs: matrix-kubectl-1.26
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl-1.26.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl-1.26.outputs.package-matrix != '[]' && needs.matrix-kubectl-1.26.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl-1.26.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl-1.26.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -45,7 +45,11 @@ env:
   kubectl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectl:
+    needs: matrix-kubectl
+    if: github.event_name != 'schedule' && needs.matrix-kubectl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectl:
+    needs: matrix-kubectl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectl.outputs.package-enabled != 'false'
+      && needs.matrix-kubectl.outputs.package-matrix != '[]' && needs.matrix-kubectl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -45,7 +45,11 @@ env:
   kubectx_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubectx:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubectx:
+    needs: matrix-kubectx
+    if: github.event_name != 'schedule' && needs.matrix-kubectx.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubectx:
+    needs: matrix-kubectx
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubectx.outputs.package-enabled != 'false'
+      && needs.matrix-kubectx.outputs.package-matrix != '[]' && needs.matrix-kubectx.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubectx.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubectx.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -45,7 +45,11 @@ env:
   kubens_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubens:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubens:
+    needs: matrix-kubens
+    if: github.event_name != 'schedule' && needs.matrix-kubens.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubens:
+    needs: matrix-kubens
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubens.outputs.package-enabled != 'false'
+      && needs.matrix-kubens.outputs.package-matrix != '[]' && needs.matrix-kubens.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubens.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubens.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -45,7 +45,11 @@ env:
   kubeval_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-kubeval:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-kubeval:
+    needs: matrix-kubeval
+    if: github.event_name != 'schedule' && needs.matrix-kubeval.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-kubeval:
+    needs: matrix-kubeval
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-kubeval.outputs.package-enabled != 'false'
+      && needs.matrix-kubeval.outputs.package-matrix != '[]' && needs.matrix-kubeval.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-kubeval.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-kubeval.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -45,7 +45,11 @@ env:
   lazydocker_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-lazydocker:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-lazydocker:
+    needs: matrix-lazydocker
+    if: github.event_name != 'schedule' && needs.matrix-lazydocker.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-lazydocker:
+    needs: matrix-lazydocker
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-lazydocker.outputs.package-enabled != 'false'
+      && needs.matrix-lazydocker.outputs.package-matrix != '[]' && needs.matrix-lazydocker.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-lazydocker.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-lazydocker.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -45,7 +45,11 @@ env:
   lectl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-lectl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-lectl:
+    needs: matrix-lectl
+    if: github.event_name != 'schedule' && needs.matrix-lectl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-lectl:
+    needs: matrix-lectl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-lectl.outputs.package-enabled != 'false'
+      && needs.matrix-lectl.outputs.package-matrix != '[]' && needs.matrix-lectl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-lectl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-lectl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -45,7 +45,11 @@ env:
   minikube_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-minikube:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-minikube:
+    needs: matrix-minikube
+    if: github.event_name != 'schedule' && needs.matrix-minikube.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-minikube:
+    needs: matrix-minikube
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-minikube.outputs.package-enabled != 'false'
+      && needs.matrix-minikube.outputs.package-matrix != '[]' && needs.matrix-minikube.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-minikube.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-minikube.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -45,7 +45,11 @@ env:
   misspell_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-misspell:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-misspell:
+    needs: matrix-misspell
+    if: github.event_name != 'schedule' && needs.matrix-misspell.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-misspell:
+    needs: matrix-misspell
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-misspell.outputs.package-enabled != 'false'
+      && needs.matrix-misspell.outputs.package-matrix != '[]' && needs.matrix-misspell.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-misspell.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-misspell.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -45,7 +45,11 @@ env:
   opa_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-opa:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-opa:
+    needs: matrix-opa
+    if: github.event_name != 'schedule' && needs.matrix-opa.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-opa:
+    needs: matrix-opa
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-opa.outputs.package-enabled != 'false'
+      && needs.matrix-opa.outputs.package-matrix != '[]' && needs.matrix-opa.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-opa.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-opa.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -45,7 +45,11 @@ env:
   pack_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-pack:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-pack:
+    needs: matrix-pack
+    if: github.event_name != 'schedule' && needs.matrix-pack.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-pack:
+    needs: matrix-pack
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-pack.outputs.package-enabled != 'false'
+      && needs.matrix-pack.outputs.package-matrix != '[]' && needs.matrix-pack.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-pack.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-pack.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -45,7 +45,11 @@ env:
   packer_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-packer:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-packer:
+    needs: matrix-packer
+    if: github.event_name != 'schedule' && needs.matrix-packer.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-packer:
+    needs: matrix-packer
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-packer.outputs.package-enabled != 'false'
+      && needs.matrix-packer.outputs.package-matrix != '[]' && needs.matrix-packer.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-packer.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-packer.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -45,7 +45,11 @@ env:
   pandoc_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-pandoc:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-pandoc:
+    needs: matrix-pandoc
+    if: github.event_name != 'schedule' && needs.matrix-pandoc.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-pandoc:
+    needs: matrix-pandoc
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-pandoc.outputs.package-enabled != 'false'
+      && needs.matrix-pandoc.outputs.package-matrix != '[]' && needs.matrix-pandoc.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-pandoc.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-pandoc.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -45,7 +45,11 @@ env:
   pgmetrics_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-pgmetrics:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-pgmetrics:
+    needs: matrix-pgmetrics
+    if: github.event_name != 'schedule' && needs.matrix-pgmetrics.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-pgmetrics:
+    needs: matrix-pgmetrics
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-pgmetrics.outputs.package-enabled != 'false'
+      && needs.matrix-pgmetrics.outputs.package-matrix != '[]' && needs.matrix-pgmetrics.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-pgmetrics.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-pgmetrics.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -45,7 +45,11 @@ env:
   pluto_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-pluto:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-pluto:
+    needs: matrix-pluto
+    if: github.event_name != 'schedule' && needs.matrix-pluto.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-pluto:
+    needs: matrix-pluto
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-pluto.outputs.package-enabled != 'false'
+      && needs.matrix-pluto.outputs.package-matrix != '[]' && needs.matrix-pluto.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-pluto.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-pluto.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -45,7 +45,11 @@ env:
   popeye_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-popeye:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-popeye:
+    needs: matrix-popeye
+    if: github.event_name != 'schedule' && needs.matrix-popeye.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-popeye:
+    needs: matrix-popeye
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-popeye.outputs.package-enabled != 'false'
+      && needs.matrix-popeye.outputs.package-matrix != '[]' && needs.matrix-popeye.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-popeye.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-popeye.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -45,7 +45,11 @@ env:
   promtool_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-promtool:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-promtool:
+    needs: matrix-promtool
+    if: github.event_name != 'schedule' && needs.matrix-promtool.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-promtool:
+    needs: matrix-promtool
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-promtool.outputs.package-enabled != 'false'
+      && needs.matrix-promtool.outputs.package-matrix != '[]' && needs.matrix-promtool.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-promtool.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-promtool.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/rainbow-text.yml
+++ b/.github/workflows/rainbow-text.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/rainbow-text.yml
+++ b/.github/workflows/rainbow-text.yml
@@ -45,7 +45,11 @@ env:
   rainbow-text_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-rainbow-text:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-rainbow-text:
+    needs: matrix-rainbow-text
+    if: github.event_name != 'schedule' && needs.matrix-rainbow-text.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-rainbow-text:
+    needs: matrix-rainbow-text
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-rainbow-text.outputs.package-enabled != 'false'
+      && needs.matrix-rainbow-text.outputs.package-matrix != '[]' && needs.matrix-rainbow-text.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-rainbow-text.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-rainbow-text.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -45,7 +45,11 @@ env:
   rakkess_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-rakkess:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-rakkess:
+    needs: matrix-rakkess
+    if: github.event_name != 'schedule' && needs.matrix-rakkess.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-rakkess:
+    needs: matrix-rakkess
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-rakkess.outputs.package-enabled != 'false'
+      && needs.matrix-rakkess.outputs.package-matrix != '[]' && needs.matrix-rakkess.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-rakkess.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-rakkess.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -45,7 +45,11 @@ env:
   rancher_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-rancher:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-rancher:
+    needs: matrix-rancher
+    if: github.event_name != 'schedule' && needs.matrix-rancher.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-rancher:
+    needs: matrix-rancher
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-rancher.outputs.package-enabled != 'false'
+      && needs.matrix-rancher.outputs.package-matrix != '[]' && needs.matrix-rancher.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-rancher.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-rancher.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -45,7 +45,11 @@ env:
   rbac-lookup_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-rbac-lookup:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-rbac-lookup:
+    needs: matrix-rbac-lookup
+    if: github.event_name != 'schedule' && needs.matrix-rbac-lookup.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-rbac-lookup:
+    needs: matrix-rbac-lookup
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-rbac-lookup.outputs.package-enabled != 'false'
+      && needs.matrix-rbac-lookup.outputs.package-matrix != '[]' && needs.matrix-rbac-lookup.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-rbac-lookup.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-rbac-lookup.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -45,7 +45,11 @@ env:
   saml2aws_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-saml2aws:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-saml2aws:
+    needs: matrix-saml2aws
+    if: github.event_name != 'schedule' && needs.matrix-saml2aws.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-saml2aws:
+    needs: matrix-saml2aws
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-saml2aws.outputs.package-enabled != 'false'
+      && needs.matrix-saml2aws.outputs.package-matrix != '[]' && needs.matrix-saml2aws.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-saml2aws.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-saml2aws.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -45,7 +45,11 @@ env:
   sentry-cli_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-sentry-cli:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-sentry-cli:
+    needs: matrix-sentry-cli
+    if: github.event_name != 'schedule' && needs.matrix-sentry-cli.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-sentry-cli:
+    needs: matrix-sentry-cli
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-sentry-cli.outputs.package-enabled != 'false'
+      && needs.matrix-sentry-cli.outputs.package-matrix != '[]' && needs.matrix-sentry-cli.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-sentry-cli.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-sentry-cli.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -45,7 +45,11 @@ env:
   shellcheck_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-shellcheck:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-shellcheck:
+    needs: matrix-shellcheck
+    if: github.event_name != 'schedule' && needs.matrix-shellcheck.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-shellcheck:
+    needs: matrix-shellcheck
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-shellcheck.outputs.package-enabled != 'false'
+      && needs.matrix-shellcheck.outputs.package-matrix != '[]' && needs.matrix-shellcheck.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-shellcheck.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-shellcheck.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -45,7 +45,11 @@ env:
   shfmt_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-shfmt:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-shfmt:
+    needs: matrix-shfmt
+    if: github.event_name != 'schedule' && needs.matrix-shfmt.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-shfmt:
+    needs: matrix-shfmt
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-shfmt.outputs.package-enabled != 'false'
+      && needs.matrix-shfmt.outputs.package-matrix != '[]' && needs.matrix-shfmt.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-shfmt.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-shfmt.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -45,7 +45,11 @@ env:
   slack-notifier_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-slack-notifier:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-slack-notifier:
+    needs: matrix-slack-notifier
+    if: github.event_name != 'schedule' && needs.matrix-slack-notifier.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-slack-notifier:
+    needs: matrix-slack-notifier
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-slack-notifier.outputs.package-enabled != 'false'
+      && needs.matrix-slack-notifier.outputs.package-matrix != '[]' && needs.matrix-slack-notifier.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-slack-notifier.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-slack-notifier.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -45,7 +45,11 @@ env:
   sops_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-sops:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-sops:
+    needs: matrix-sops
+    if: github.event_name != 'schedule' && needs.matrix-sops.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-sops:
+    needs: matrix-sops
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-sops.outputs.package-enabled != 'false'
+      && needs.matrix-sops.outputs.package-matrix != '[]' && needs.matrix-sops.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-sops.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-sops.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/spacectl.yml
+++ b/.github/workflows/spacectl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/spacectl.yml
+++ b/.github/workflows/spacectl.yml
@@ -45,7 +45,11 @@ env:
   spacectl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-spacectl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-spacectl:
+    needs: matrix-spacectl
+    if: github.event_name != 'schedule' && needs.matrix-spacectl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-spacectl:
+    needs: matrix-spacectl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-spacectl.outputs.package-enabled != 'false'
+      && needs.matrix-spacectl.outputs.package-matrix != '[]' && needs.matrix-spacectl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-spacectl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-spacectl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/spotctl.yml
+++ b/.github/workflows/spotctl.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/spotctl.yml
+++ b/.github/workflows/spotctl.yml
@@ -45,7 +45,11 @@ env:
   spotctl_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-spotctl:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-spotctl:
+    needs: matrix-spotctl
+    if: github.event_name != 'schedule' && needs.matrix-spotctl.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-spotctl:
+    needs: matrix-spotctl
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-spotctl.outputs.package-enabled != 'false'
+      && needs.matrix-spotctl.outputs.package-matrix != '[]' && needs.matrix-spotctl.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-spotctl.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-spotctl.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/sshm.yml
+++ b/.github/workflows/sshm.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/sshm.yml
+++ b/.github/workflows/sshm.yml
@@ -45,7 +45,11 @@ env:
   sshm_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-sshm:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-sshm:
+    needs: matrix-sshm
+    if: github.event_name != 'schedule' && needs.matrix-sshm.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-sshm:
+    needs: matrix-sshm
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-sshm.outputs.package-enabled != 'false'
+      && needs.matrix-sshm.outputs.package-matrix != '[]' && needs.matrix-sshm.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-sshm.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-sshm.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -45,7 +45,11 @@ env:
   stern_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-stern:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-stern:
+    needs: matrix-stern
+    if: github.event_name != 'schedule' && needs.matrix-stern.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-stern:
+    needs: matrix-stern
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-stern.outputs.package-enabled != 'false'
+      && needs.matrix-stern.outputs.package-matrix != '[]' && needs.matrix-stern.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-stern.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-stern.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -45,7 +45,11 @@ env:
   sudosh_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-sudosh:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-sudosh:
+    needs: matrix-sudosh
+    if: github.event_name != 'schedule' && needs.matrix-sudosh.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-sudosh:
+    needs: matrix-sudosh
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-sudosh.outputs.package-enabled != 'false'
+      && needs.matrix-sudosh.outputs.package-matrix != '[]' && needs.matrix-sudosh.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-sudosh.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-sudosh.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/teleport-4.3.yml
+++ b/.github/workflows/teleport-4.3.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/teleport-4.3.yml
+++ b/.github/workflows/teleport-4.3.yml
@@ -45,7 +45,11 @@ env:
   teleport-4.3_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-teleport-4.3:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-teleport-4.3:
+    needs: matrix-teleport-4.3
+    if: github.event_name != 'schedule' && needs.matrix-teleport-4.3.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-teleport-4.3:
+    needs: matrix-teleport-4.3
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-teleport-4.3.outputs.package-enabled != 'false'
+      && needs.matrix-teleport-4.3.outputs.package-matrix != '[]' && needs.matrix-teleport-4.3.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-teleport-4.3.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-teleport-4.3.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/teleport-4.4.yml
+++ b/.github/workflows/teleport-4.4.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/teleport-4.4.yml
+++ b/.github/workflows/teleport-4.4.yml
@@ -45,7 +45,11 @@ env:
   teleport-4.4_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-teleport-4.4:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-teleport-4.4:
+    needs: matrix-teleport-4.4
+    if: github.event_name != 'schedule' && needs.matrix-teleport-4.4.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-teleport-4.4:
+    needs: matrix-teleport-4.4
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-teleport-4.4.outputs.package-enabled != 'false'
+      && needs.matrix-teleport-4.4.outputs.package-matrix != '[]' && needs.matrix-teleport-4.4.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-teleport-4.4.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-teleport-4.4.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/teleport-5.0.yml
+++ b/.github/workflows/teleport-5.0.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/teleport-5.0.yml
+++ b/.github/workflows/teleport-5.0.yml
@@ -45,7 +45,11 @@ env:
   teleport-5.0_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-teleport-5.0:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-teleport-5.0:
+    needs: matrix-teleport-5.0
+    if: github.event_name != 'schedule' && needs.matrix-teleport-5.0.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-teleport-5.0:
+    needs: matrix-teleport-5.0
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-teleport-5.0.outputs.package-enabled != 'false'
+      && needs.matrix-teleport-5.0.outputs.package-matrix != '[]' && needs.matrix-teleport-5.0.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-teleport-5.0.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-teleport-5.0.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -45,7 +45,11 @@ env:
   teleport_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-teleport:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-teleport:
+    needs: matrix-teleport
+    if: github.event_name != 'schedule' && needs.matrix-teleport.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-teleport:
+    needs: matrix-teleport
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-teleport.outputs.package-enabled != 'false'
+      && needs.matrix-teleport.outputs.package-matrix != '[]' && needs.matrix-teleport.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-teleport.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-teleport.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -45,7 +45,11 @@ env:
   terraform-0.11_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-0.11:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-0.11:
+    needs: matrix-terraform-0.11
+    if: github.event_name != 'schedule' && needs.matrix-terraform-0.11.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-0.11:
+    needs: matrix-terraform-0.11
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-0.11.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-0.11.outputs.package-matrix != '[]' && needs.matrix-terraform-0.11.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-0.11.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-0.11.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -45,7 +45,11 @@ env:
   terraform-0.12_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-0.12:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-0.12:
+    needs: matrix-terraform-0.12
+    if: github.event_name != 'schedule' && needs.matrix-terraform-0.12.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-0.12:
+    needs: matrix-terraform-0.12
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-0.12.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-0.12.outputs.package-matrix != '[]' && needs.matrix-terraform-0.12.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-0.12.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-0.12.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -45,7 +45,11 @@ env:
   terraform-0.13_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-0.13:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-0.13:
+    needs: matrix-terraform-0.13
+    if: github.event_name != 'schedule' && needs.matrix-terraform-0.13.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-0.13:
+    needs: matrix-terraform-0.13
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-0.13.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-0.13.outputs.package-matrix != '[]' && needs.matrix-terraform-0.13.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-0.13.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-0.13.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-0.14.yml
+++ b/.github/workflows/terraform-0.14.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-0.14.yml
+++ b/.github/workflows/terraform-0.14.yml
@@ -45,7 +45,11 @@ env:
   terraform-0.14_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-0.14:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-0.14:
+    needs: matrix-terraform-0.14
+    if: github.event_name != 'schedule' && needs.matrix-terraform-0.14.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-0.14:
+    needs: matrix-terraform-0.14
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-0.14.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-0.14.outputs.package-matrix != '[]' && needs.matrix-terraform-0.14.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-0.14.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-0.14.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-0.15.yml
+++ b/.github/workflows/terraform-0.15.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-0.15.yml
+++ b/.github/workflows/terraform-0.15.yml
@@ -45,7 +45,11 @@ env:
   terraform-0.15_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-0.15:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-0.15:
+    needs: matrix-terraform-0.15
+    if: github.event_name != 'schedule' && needs.matrix-terraform-0.15.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-0.15:
+    needs: matrix-terraform-0.15
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-0.15.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-0.15.outputs.package-matrix != '[]' && needs.matrix-terraform-0.15.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-0.15.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-0.15.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-1.yml
+++ b/.github/workflows/terraform-1.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-1.yml
+++ b/.github/workflows/terraform-1.yml
@@ -45,7 +45,11 @@ env:
   terraform-1_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-1:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-1:
+    needs: matrix-terraform-1
+    if: github.event_name != 'schedule' && needs.matrix-terraform-1.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-1:
+    needs: matrix-terraform-1
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-1.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-1.outputs.package-matrix != '[]' && needs.matrix-terraform-1.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-1.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-1.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-config-inspect.yml
+++ b/.github/workflows/terraform-config-inspect.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-config-inspect.yml
+++ b/.github/workflows/terraform-config-inspect.yml
@@ -45,7 +45,11 @@ env:
   terraform-config-inspect_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-config-inspect:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-config-inspect:
+    needs: matrix-terraform-config-inspect
+    if: github.event_name != 'schedule' && needs.matrix-terraform-config-inspect.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-config-inspect:
+    needs: matrix-terraform-config-inspect
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-config-inspect.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-config-inspect.outputs.package-matrix != '[]' && needs.matrix-terraform-config-inspect.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-config-inspect.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-config-inspect.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -45,7 +45,11 @@ env:
   terraform-docs_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-docs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-docs:
+    needs: matrix-terraform-docs
+    if: github.event_name != 'schedule' && needs.matrix-terraform-docs.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-docs:
+    needs: matrix-terraform-docs
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-docs.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-docs.outputs.package-matrix != '[]' && needs.matrix-terraform-docs.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-docs.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-docs.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform-module-versions.yml
+++ b/.github/workflows/terraform-module-versions.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform-module-versions.yml
+++ b/.github/workflows/terraform-module-versions.yml
@@ -45,7 +45,11 @@ env:
   terraform-module-versions_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform-module-versions:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform-module-versions:
+    needs: matrix-terraform-module-versions
+    if: github.event_name != 'schedule' && needs.matrix-terraform-module-versions.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform-module-versions:
+    needs: matrix-terraform-module-versions
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform-module-versions.outputs.package-enabled != 'false'
+      && needs.matrix-terraform-module-versions.outputs.package-matrix != '[]' && needs.matrix-terraform-module-versions.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform-module-versions.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform-module-versions.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -45,7 +45,11 @@ env:
   terraform_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform:
+    needs: matrix-terraform
+    if: github.event_name != 'schedule' && needs.matrix-terraform.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform:
+    needs: matrix-terraform
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform.outputs.package-enabled != 'false'
+      && needs.matrix-terraform.outputs.package-matrix != '[]' && needs.matrix-terraform.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -45,7 +45,11 @@ env:
   terraform_0.11_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform_0.11:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform_0.11:
+    needs: matrix-terraform_0.11
+    if: github.event_name != 'schedule' && needs.matrix-terraform_0.11.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform_0.11:
+    needs: matrix-terraform_0.11
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform_0.11.outputs.package-enabled != 'false'
+      && needs.matrix-terraform_0.11.outputs.package-matrix != '[]' && needs.matrix-terraform_0.11.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform_0.11.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform_0.11.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -45,7 +45,11 @@ env:
   terraform_0.12_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform_0.12:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform_0.12:
+    needs: matrix-terraform_0.12
+    if: github.event_name != 'schedule' && needs.matrix-terraform_0.12.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform_0.12:
+    needs: matrix-terraform_0.12
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform_0.12.outputs.package-enabled != 'false'
+      && needs.matrix-terraform_0.12.outputs.package-matrix != '[]' && needs.matrix-terraform_0.12.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform_0.12.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform_0.12.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -45,7 +45,11 @@ env:
   terraform_0.13_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terraform_0.13:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terraform_0.13:
+    needs: matrix-terraform_0.13
+    if: github.event_name != 'schedule' && needs.matrix-terraform_0.13.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terraform_0.13:
+    needs: matrix-terraform_0.13
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terraform_0.13.outputs.package-enabled != 'false'
+      && needs.matrix-terraform_0.13.outputs.package-matrix != '[]' && needs.matrix-terraform_0.13.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terraform_0.13.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terraform_0.13.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -45,7 +45,11 @@ env:
   terragrunt_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terragrunt:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terragrunt:
+    needs: matrix-terragrunt
+    if: github.event_name != 'schedule' && needs.matrix-terragrunt.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terragrunt:
+    needs: matrix-terragrunt
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terragrunt.outputs.package-enabled != 'false'
+      && needs.matrix-terragrunt.outputs.package-matrix != '[]' && needs.matrix-terragrunt.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terragrunt.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terragrunt.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -45,7 +45,11 @@ env:
   terrahelp_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-terrahelp:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-terrahelp:
+    needs: matrix-terrahelp
+    if: github.event_name != 'schedule' && needs.matrix-terrahelp.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-terrahelp:
+    needs: matrix-terrahelp
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-terrahelp.outputs.package-enabled != 'false'
+      && needs.matrix-terrahelp.outputs.package-matrix != '[]' && needs.matrix-terrahelp.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-terrahelp.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-terrahelp.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -45,7 +45,11 @@ env:
   tflint_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-tflint:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-tflint:
+    needs: matrix-tflint
+    if: github.event_name != 'schedule' && needs.matrix-tflint.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-tflint:
+    needs: matrix-tflint
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-tflint.outputs.package-enabled != 'false'
+      && needs.matrix-tflint.outputs.package-matrix != '[]' && needs.matrix-tflint.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-tflint.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-tflint.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/tfschema.yml
+++ b/.github/workflows/tfschema.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/tfschema.yml
+++ b/.github/workflows/tfschema.yml
@@ -45,7 +45,11 @@ env:
   tfschema_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-tfschema:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-tfschema:
+    needs: matrix-tfschema
+    if: github.event_name != 'schedule' && needs.matrix-tfschema.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-tfschema:
+    needs: matrix-tfschema
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-tfschema.outputs.package-enabled != 'false'
+      && needs.matrix-tfschema.outputs.package-matrix != '[]' && needs.matrix-tfschema.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-tfschema.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-tfschema.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -45,7 +45,11 @@ env:
   tfsec_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-tfsec:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-tfsec:
+    needs: matrix-tfsec
+    if: github.event_name != 'schedule' && needs.matrix-tfsec.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-tfsec:
+    needs: matrix-tfsec
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-tfsec.outputs.package-enabled != 'false'
+      && needs.matrix-tfsec.outputs.package-matrix != '[]' && needs.matrix-tfsec.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-tfsec.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-tfsec.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -45,7 +45,11 @@ env:
   thanos_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-thanos:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-thanos:
+    needs: matrix-thanos
+    if: github.event_name != 'schedule' && needs.matrix-thanos.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-thanos:
+    needs: matrix-thanos
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-thanos.outputs.package-enabled != 'false'
+      && needs.matrix-thanos.outputs.package-matrix != '[]' && needs.matrix-thanos.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-thanos.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-thanos.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -45,7 +45,11 @@ env:
   trivy_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-trivy:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-trivy:
+    needs: matrix-trivy
+    if: github.event_name != 'schedule' && needs.matrix-trivy.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-trivy:
+    needs: matrix-trivy
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-trivy.outputs.package-enabled != 'false'
+      && needs.matrix-trivy.outputs.package-matrix != '[]' && needs.matrix-trivy.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-trivy.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-trivy.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -45,7 +45,11 @@ env:
   variant_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-variant:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-variant:
+    needs: matrix-variant
+    if: github.event_name != 'schedule' && needs.matrix-variant.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-variant:
+    needs: matrix-variant
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-variant.outputs.package-enabled != 'false'
+      && needs.matrix-variant.outputs.package-matrix != '[]' && needs.matrix-variant.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-variant.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-variant.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -45,7 +45,11 @@ env:
   variant2_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-variant2:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-variant2:
+    needs: matrix-variant2
+    if: github.event_name != 'schedule' && needs.matrix-variant2.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-variant2:
+    needs: matrix-variant2
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-variant2.outputs.package-enabled != 'false'
+      && needs.matrix-variant2.outputs.package-matrix != '[]' && needs.matrix-variant2.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-variant2.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-variant2.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -45,7 +45,11 @@ env:
   vault_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-vault:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-vault:
+    needs: matrix-vault
+    if: github.event_name != 'schedule' && needs.matrix-vault.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-vault:
+    needs: matrix-vault
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-vault.outputs.package-enabled != 'false'
+      && needs.matrix-vault.outputs.package-matrix != '[]' && needs.matrix-vault.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-vault.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-vault.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/vendir.yml
+++ b/.github/workflows/vendir.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/vendir.yml
+++ b/.github/workflows/vendir.yml
@@ -45,7 +45,11 @@ env:
   vendir_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-vendir:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-vendir:
+    needs: matrix-vendir
+    if: github.event_name != 'schedule' && needs.matrix-vendir.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-vendir:
+    needs: matrix-vendir
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-vendir.outputs.package-enabled != 'false'
+      && needs.matrix-vendir.outputs.package-matrix != '[]' && needs.matrix-vendir.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-vendir.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-vendir.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -45,7 +45,11 @@ env:
   venona_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-venona:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-venona:
+    needs: matrix-venona
+    if: github.event_name != 'schedule' && needs.matrix-venona.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-venona:
+    needs: matrix-venona
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-venona.outputs.package-enabled != 'false'
+      && needs.matrix-venona.outputs.package-matrix != '[]' && needs.matrix-venona.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-venona.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-venona.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -45,7 +45,11 @@ env:
   vert_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-vert:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-vert:
+    needs: matrix-vert
+    if: github.event_name != 'schedule' && needs.matrix-vert.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-vert:
+    needs: matrix-vert
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-vert.outputs.package-enabled != 'false'
+      && needs.matrix-vert.outputs.package-matrix != '[]' && needs.matrix-vert.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-vert.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-vert.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/yajsv.yml
+++ b/.github/workflows/yajsv.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/yajsv.yml
+++ b/.github/workflows/yajsv.yml
@@ -45,7 +45,11 @@ env:
   yajsv_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-yajsv:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-yajsv:
+    needs: matrix-yajsv
+    if: github.event_name != 'schedule' && needs.matrix-yajsv.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-yajsv:
+    needs: matrix-yajsv
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-yajsv.outputs.package-enabled != 'false'
+      && needs.matrix-yajsv.outputs.package-matrix != '[]' && needs.matrix-yajsv.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-yajsv.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-yajsv.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -176,6 +176,7 @@ jobs:
         - runs-on:
           - "self-hosted"
           - "arm64"
+          - "packages"
         # By including `arch: amd64` here, we override the `runs-on` value `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64.

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -45,7 +45,11 @@ env:
   yq_RELEASE: ${{ github.event.inputs.release_number_override }}
 
 jobs:
-  matrix:
+  # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
+  # so each job must have a unique name for the rules to work properly.
+  # See https://github.com/Mergifyio/mergify/discussions/5082
+  # and https://github.com/Mergifyio/mergify/issues/5083
+  matrix-yq:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     outputs:
@@ -70,9 +74,9 @@ jobs:
 
   # Build for alpine linux
   # Kept separate because it is old and slightly different than the other package builds
-  alpine:
-    needs: matrix
-    if: github.event_name != 'schedule' && needs.matrix.outputs.apk-enabled != 'false'
+  alpine-yq:
+    needs: matrix-yq
+    if: github.event_name != 'schedule' && needs.matrix-yq.outputs.apk-enabled != 'false'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -152,18 +156,18 @@ jobs:
           no-wait-for-sync: 'true'                          # Skip the waiting for package synchronisation (i.e. upload only)
 
   # Build packages with fpm package manager
-  package:
-    needs: matrix
+  package-yq:
+    needs: matrix-yq
     # Should not be needed, but without these conditions, this job would fail with an error if the matrix is []
     # and would run with package-type empty if matrix is ["apk"]
     if: >
-      github.event_name != 'schedule' && needs.matrix.outputs.package-enabled != 'false'
-      && needs.matrix.outputs.package-matrix != '[]' && needs.matrix.outputs.package-matrix != '["apk"]'
+      github.event_name != 'schedule' && needs.matrix-yq.outputs.package-enabled != 'false'
+      && needs.matrix-yq.outputs.package-matrix != '[]' && needs.matrix-yq.outputs.package-matrix != '["apk"]'
 
     strategy:
       matrix:
-        package-type: ${{ fromJSON(needs.matrix.outputs.package-matrix) }}
-        arch: ${{ fromJSON(needs.matrix.outputs.arch-matrix) }}
+        package-type: ${{ fromJSON(needs.matrix-yq.outputs.package-matrix) }}
+        arch: ${{ fromJSON(needs.matrix-yq.outputs.arch-matrix) }}
         exclude:
         - package-type: 'apk'
         include:

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -42,10 +42,10 @@ github-status-updater*    0.7.0      Command line utility for updating GitHub co
 gitleaks                  8.16.3     Audit git repos for secrets 🔑
 go-jsonnet                0.20.0     This an implementation of Jsonnet in pure Go.
 gomplate                  3.11.5     A flexible commandline tool for template rendering. Supports lots of local and remote datasources.
-gonsul*                   1.0.2      A stand-alone alternative to git2consul 
+gonsul                    1.0.2      A stand-alone alternative to git2consul 
 goofys*                   0.24.0     a high-performance, POSIX-ish Amazon S3 file system written in Go
 gosu                      1.16.0     Simple Go-based setuid+setgid+setgroups+exec
-gotop                     3.0.0      A terminal based graphical activity monitor inspired by gtop and vtop
+gotop*                    3.0.0      A terminal based graphical activity monitor inspired by gtop and vtop
 grpcurl                   1.8.7      Like cURL, but for gRPC: Command-line tool for interacting with gRPC servers
 hcledit                   0.2.7      A command line editor for HCL
 helm                      3.11.3     The Kubernetes Package Manager
@@ -102,7 +102,7 @@ popeye                    0.11.1     A Kubernetes cluster resource sanitizer
 promtool                  2.43.0     Prometheus CLI tool
 rainbow-text              1.2.1      Tasty rainbows for your terminal! (lolcat clone)
 rakkess*                  0.5.0      Review Access - kubectl plugin to show an access matrix for all available resources
-rancher                   2.7.0      Rancher CLI
+rancher*                  2.7.0      Rancher CLI
 rbac-lookup               0.10.1     Find Kubernetes roles and cluster roles bound to any user, service account, or group name.
 retry                     OBSOLETE   ♻️ Functional mechanism based on channels to perform actions repetitively until successful.
 saml2aws                  2.36.6     CLI tool which enables you to login and retrieve AWS temporary credentials using a SAML IDP
@@ -152,7 +152,7 @@ vault                     1.13.1     Hashicorp vault
 vendir                    0.33.1      Easy way to vendor portions of git repos, github releases, helm charts, docker image contents, etc. declaratively.
 venona*                   1.9.14     Codefresh runtime-environment agent
 vert                      0.1.0      Simple CLI for comparing two or more versions
-yajsv*                    1.4.1      Yet Another JSON Schema Validator [CLI]
+yajsv                     1.4.1      Yet Another JSON Schema Validator [CLI]
 yq                        4.33.3     yq is a portable command-line YAML processor
 ```
 <!-- markdownlint-restore -->


### PR DESCRIPTION

## what

- Strengthen the rules required for automatic approving and merging via Mergify
- Give jobs unique names so that Mergify can tell them apart

## why

- Previous rules failed to stop #3484 from being merged despite the failure to build the package because a second package built without error. The new rules are intended to prevent a repeat of that situation. 

## references
- https://docs.mergify.com/conditions/#validating-all-status-checks
- #3484 
- Private communication from support@mergify.com says GitHub does not provide enough information to differentiate the different CI jobs with overlapping names. Mergify only keeps the last reported one. Inspection of GitHub API results shows that despite the workflow name appearing in the UI, the check run data only includes the name of the job. 

