### PR TITLE
Update auto-update-packages workflow actions to Node 20

### DIFF
--- a/.github/workflows/auto-update-packages.yml
+++ b/.github/workflows/auto-update-packages.yml
@@ -147,7 +147,7 @@ jobs:
         - yq
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get current package information
         shell: bash
@@ -178,7 +178,7 @@ jobs:
           make readme
 
       - name: Create Pull Request
-        uses: cloudposse/actions/github/create-pull-request@0.32.0
+        uses: peter-evans/create-pull-request@v5
         if: steps.update.outputs.package_version != steps.current.outputs.package_version
         with:
           token: ${{ secrets.GITHUB_BOT_TOKEN }}


### PR DESCRIPTION
## what

- Update `auto-update-packages` workflow to use current actions

## why

- Actions being used were outdated, and in some cases used Node.JS v16, which is now deprecated

## references

- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/


