### PR TITLE
[spotctl] Latest release deleted, allow auto-update to fail

### DIFF
--- a/vendor/spotctl/Makefile
+++ b/vendor/spotctl/Makefile
@@ -3,6 +3,7 @@
 export VENDOR ?= spotinst
 export DOWNLOAD_URL ?= $(PACKAGE_REPO_URL)/releases/download/v$(PACKAGE_VERSION)/$(PACKAGE_NAME)-$(OS)-$(ARCH)-$(PACKAGE_VERSION).tar.gz
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
+export AUTO_UPDATE_ENABLED := softfail
 
 include ../../tasks/Makefile.vendor_includes
 


### PR DESCRIPTION
## what

- Do not consider it an error if auto-update of `spotctl` fails

## why

- Spotctl's current release, v0.35.0, was deleted without explanation, though it persists as a tag. The fact that the current package release is not available in the list of releases is considered by `packages` to be a failure, but for `spotctl` this expected behavior, at least for now.

## references

- https://github.com/spotinst/spotctl/releases
- https://github.com/spotinst/spotctl/tags


