### PR TITLE
Update build OSes, pre-install Python

### DIFF
--- a/.github/workflows/apkbuild.yml
+++ b/.github/workflows/apkbuild.yml
@@ -31,7 +31,7 @@ jobs:
           BUILDER: apkbuild
           MATRIX_TAG: ${{matrix.alpine}}
         run: |
-          DOCKER_IMAGE=${{ github.repository }}-${BUILDER}
+          DOCKER_IMAGE=ghcr.io/${{ github.repository }}-${BUILDER}
           TAGS="${DOCKER_IMAGE}:${MATRIX_TAG},${DOCKER_IMAGE}:latest"
           COMMIT_SHA="${GITHUB_SHA}"
           if [[ $GITHUB_REF == refs/tags/* ]]; then
@@ -50,8 +50,9 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
       - name: "Build and push APK builder docker image to DockerHub"
         id: docker_build_builder
         uses: docker/build-push-action@v5

--- a/.github/workflows/apkbuild.yml
+++ b/.github/workflows/apkbuild.yml
@@ -14,6 +14,12 @@ on:
     paths:
       - apk/**
 
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -47,7 +53,7 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+      - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/debbuild.yml
+++ b/.github/workflows/debbuild.yml
@@ -16,6 +16,12 @@ on:
       - deb/**
       - .github/workflows/debbuild.yml
 
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/debbuild.yml
+++ b/.github/workflows/debbuild.yml
@@ -32,7 +32,7 @@ jobs:
         BUILDER: debbuild
         MATRIX_TAG: ${{matrix.debian}}
       run: |
-        DOCKER_IMAGE=${{ github.repository }}-${BUILDER}
+        DOCKER_IMAGE=ghcr.io/${{ github.repository }}-${BUILDER}
         TAGS="${DOCKER_IMAGE}:${MATRIX_TAG},${DOCKER_IMAGE}:latest"
         COMMIT_SHA="${GITHUB_SHA}"
         if [[ $GITHUB_REF == refs/tags/* ]]; then
@@ -53,8 +53,9 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        registry: ghcr.io
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
     - name: "Build and push Debian builder docker image to DockerHub"
       id: docker_build_builder
       uses: docker/build-push-action@v5

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         centos:
-        - 'centos8'
+        - 'ubi'
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v4

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -16,6 +16,12 @@ on:
     - rpm/**
     - .github/workflows/rpmbuild.yml
 
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/rpmbuild.yml
+++ b/.github/workflows/rpmbuild.yml
@@ -32,7 +32,7 @@ jobs:
         BUILDER: rpmbuild
         MATRIX_TAG: ${{matrix.centos}}
       run: |
-        DOCKER_IMAGE=${{ github.repository }}-${BUILDER}
+        DOCKER_IMAGE=ghcr.io/${{ github.repository }}-${BUILDER}
         TAGS="${DOCKER_IMAGE}:${MATRIX_TAG},${DOCKER_IMAGE}:latest"
         COMMIT_SHA="${GITHUB_SHA}"
         if [[ $GITHUB_REF == refs/tags/* ]]; then
@@ -53,8 +53,9 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        registry: ghcr.io
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
     - name: "Build and push RPM builder docker image to DockerHub"
       id: docker_build_builder
       uses: docker/build-push-action@v5

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ docker/build/apk/shell run/apk:
 # MATRIX BUILD
 docker/build/deb/shell docker/build/deb/test run/deb : BUILDER_VERSION=stable-slim
 
-docker/build/rpm/shell docker/build/rpm/test run/rpm : BUILDER_VERSION=centos8
+docker/build/rpm/shell docker/build/rpm/test run/rpm : BUILDER_VERSION=ubi
 
 ## Build package as a test
 docker/build/%/test:

--- a/apk/Dockerfile-alpine
+++ b/apk/Dockerfile-alpine
@@ -1,5 +1,5 @@
 # Need to use version number so that it gets updated here and triggers a build
-FROM alpine:3.17.3
+FROM alpine:3.19.1
 
 ENV LC_ALL=C.UTF-8
 ENV PS1="(apk) \w \$ "
@@ -16,6 +16,7 @@ RUN apk add --no-cache bash curl && \
 RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 
 RUN apk update && \
-    apk add make curl alpine-sdk shadow bash jq sudo go
+    apk add make curl alpine-sdk shadow bash jq sudo go  && \
+    apk add --update -U python3 python3-dev py3-pip libffi-dev gcc linux-headers musl-dev openssl-dev
 
 RUN echo "auth       sufficient   pam_shells.so" > /etc/pam.d/chsh

--- a/deb/Dockerfile.stable-slim
+++ b/deb/Dockerfile.stable-slim
@@ -1,5 +1,8 @@
 # Need to use version number so that it gets updated here and triggers a build
-FROM debian:11.5-slim
+ARG PYTHON_VERSION=3.12.3
+ARG DEBIAN_CODENAME=bookworm
+
+FROM python:${PYTHON_VERSION}-slim-${DEBIAN_CODENAME}
 
 ENV LC_ALL=C.UTF-8
 ENV PS1="(deb) \w \$ "

--- a/rpm/Dockerfile.ubi
+++ b/rpm/Dockerfile.ubi
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi
+# UBI replaces Centos
+FROM registry.access.redhat.com/ubi9/ubi
 
 ENV LC_ALL=C.UTF-8
 ENV PS1="(rpm) \w \$ "
@@ -6,6 +7,8 @@ ENV PS1="(rpm) \w \$ "
 RUN yum clean all && yum -y install ruby-devel gcc make rpm-build rubygems git zip bzip2 jq which
 # install sudo, needed by package sudosh, and protected, so it is nearly impossible to remove
 RUN yum -y install sudo
+
+RUN yum -y install python3.12 python3-pip
 
 # https://github.com/jordansissel/fpm/issues/1663
 #  # # RUN gem install  --no-document backports -v 3.15.0


### PR DESCRIPTION
## what

- Publish builder images to GitHub registry (`ghcr.io`) rather than Docker Hub
- Pre-install Python

Update operating systems on builders:
- Alpine 3.17.3 -> 3.19.1
- Debian 11.5 -> 12 via Python
- ubi8 -> ubi9 (Centos replacements)

## why

- Avoid rate limiting issues when rebuilding all packages
- Cloudsmith non-dockerized action requires Python, which turns out to be difficult to install when running a GitHub action in a Docker container
- Ensure packages work on current versions of OS

## references

- https://github.com/actions/setup-python/issues
- #4724

