### PR TITLE
Use cloudsmith action 0.5.4 -> 0.6.10, new builder hosted by ghcr.io

### DIFF
--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/%PACKAGE_NAME%/**
-      - .github/workflows/%PACKAGE_NAME%.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/%PACKAGE_NAME%.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/%PACKAGE_NAME%/**
       - .github/workflows/%PACKAGE_NAME%.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   %PACKAGE_NAME%_VERSION: ${{ inputs.package_version_override }}
   %PACKAGE_NAME%_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-%PACKAGE_JSON_NAME%:
     needs: matrix-%PACKAGE_JSON_NAME%
     if: github.event_name != 'schedule' && needs.matrix-%PACKAGE_JSON_NAME%.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/amazon-ecr-credential-helper.yml
+++ b/.github/workflows/amazon-ecr-credential-helper.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/amazon-ecr-credential-helper/**
-      - .github/workflows/amazon-ecr-credential-helper.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/amazon-ecr-credential-helper.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/amazon-ecr-credential-helper/**
       - .github/workflows/amazon-ecr-credential-helper.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   amazon-ecr-credential-helper_VERSION: ${{ inputs.package_version_override }}
   amazon-ecr-credential-helper_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-amazon-ecr-credential-helper:
     needs: matrix-amazon-ecr-credential-helper
     if: github.event_name != 'schedule' && needs.matrix-amazon-ecr-credential-helper.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/amazon-ecr-credential-helper.yml
+++ b/.github/workflows/amazon-ecr-credential-helper.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/amtool/**
-      - .github/workflows/amtool.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/amtool.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/amtool/**
       - .github/workflows/amtool.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   amtool_VERSION: ${{ inputs.package_version_override }}
   amtool_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-amtool:
     needs: matrix-amtool
     if: github.event_name != 'schedule' && needs.matrix-amtool.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/argocd/**
-      - .github/workflows/argocd.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/argocd.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/argocd/**
       - .github/workflows/argocd.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   argocd_VERSION: ${{ inputs.package_version_override }}
   argocd_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-argocd:
     needs: matrix-argocd
     if: github.event_name != 'schedule' && needs.matrix-argocd.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/assume-role/**
-      - .github/workflows/assume-role.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/assume-role.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/assume-role/**
       - .github/workflows/assume-role.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   assume-role_VERSION: ${{ inputs.package_version_override }}
   assume-role_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-assume-role:
     needs: matrix-assume-role
     if: github.event_name != 'schedule' && needs.matrix-assume-role.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/atlantis/**
-      - .github/workflows/atlantis.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/atlantis.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/atlantis/**
       - .github/workflows/atlantis.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   atlantis_VERSION: ${{ inputs.package_version_override }}
   atlantis_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-atlantis:
     needs: matrix-atlantis
     if: github.event_name != 'schedule' && needs.matrix-atlantis.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/atmos/**
-      - .github/workflows/atmos.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/atmos.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/atmos/**
       - .github/workflows/atmos.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   atmos_VERSION: ${{ inputs.package_version_override }}
   atmos_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-atmos:
     needs: matrix-atmos
     if: github.event_name != 'schedule' && needs.matrix-atmos.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/awless/**
-      - .github/workflows/awless.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/awless.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/awless/**
       - .github/workflows/awless.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   awless_VERSION: ${{ inputs.package_version_override }}
   awless_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-awless:
     needs: matrix-awless
     if: github.event_name != 'schedule' && needs.matrix-awless.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/aws-copilot-cli.yml
+++ b/.github/workflows/aws-copilot-cli.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/aws-copilot-cli/**
-      - .github/workflows/aws-copilot-cli.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/aws-copilot-cli.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/aws-copilot-cli/**
       - .github/workflows/aws-copilot-cli.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   aws-copilot-cli_VERSION: ${{ inputs.package_version_override }}
   aws-copilot-cli_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-aws-copilot-cli:
     needs: matrix-aws-copilot-cli
     if: github.event_name != 'schedule' && needs.matrix-aws-copilot-cli.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-copilot-cli.yml
+++ b/.github/workflows/aws-copilot-cli.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/aws-iam-authenticator/**
-      - .github/workflows/aws-iam-authenticator.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/aws-iam-authenticator.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/aws-iam-authenticator/**
       - .github/workflows/aws-iam-authenticator.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   aws-iam-authenticator_VERSION: ${{ inputs.package_version_override }}
   aws-iam-authenticator_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-aws-iam-authenticator:
     needs: matrix-aws-iam-authenticator
     if: github.event_name != 'schedule' && needs.matrix-aws-iam-authenticator.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/aws-nuke/**
-      - .github/workflows/aws-nuke.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/aws-nuke.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/aws-nuke/**
       - .github/workflows/aws-nuke.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   aws-nuke_VERSION: ${{ inputs.package_version_override }}
   aws-nuke_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-aws-nuke:
     needs: matrix-aws-nuke
     if: github.event_name != 'schedule' && needs.matrix-aws-nuke.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/aws-vault/**
-      - .github/workflows/aws-vault.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/aws-vault.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/aws-vault/**
       - .github/workflows/aws-vault.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   aws-vault_VERSION: ${{ inputs.package_version_override }}
   aws-vault_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-aws-vault:
     needs: matrix-aws-vault
     if: github.event_name != 'schedule' && needs.matrix-aws-vault.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/cfssl/**
-      - .github/workflows/cfssl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/cfssl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/cfssl/**
       - .github/workflows/cfssl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   cfssl_VERSION: ${{ inputs.package_version_override }}
   cfssl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-cfssl:
     needs: matrix-cfssl
     if: github.event_name != 'schedule' && needs.matrix-cfssl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/cfssljson/**
-      - .github/workflows/cfssljson.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/cfssljson.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/cfssljson/**
       - .github/workflows/cfssljson.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   cfssljson_VERSION: ${{ inputs.package_version_override }}
   cfssljson_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-cfssljson:
     needs: matrix-cfssljson
     if: github.event_name != 'schedule' && needs.matrix-cfssljson.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/chamber/**
-      - .github/workflows/chamber.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/chamber.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/chamber/**
       - .github/workflows/chamber.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   chamber_VERSION: ${{ inputs.package_version_override }}
   chamber_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-chamber:
     needs: matrix-chamber
     if: github.event_name != 'schedule' && needs.matrix-chamber.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/cilium-cli.yml
+++ b/.github/workflows/cilium-cli.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/cilium-cli/**
-      - .github/workflows/cilium-cli.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/cilium-cli.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/cilium-cli/**
       - .github/workflows/cilium-cli.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   cilium-cli_VERSION: ${{ inputs.package_version_override }}
   cilium-cli_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-cilium-cli:
     needs: matrix-cilium-cli
     if: github.event_name != 'schedule' && needs.matrix-cilium-cli.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cilium-cli.yml
+++ b/.github/workflows/cilium-cli.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/cli53/**
-      - .github/workflows/cli53.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/cli53.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/cli53/**
       - .github/workflows/cli53.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   cli53_VERSION: ${{ inputs.package_version_override }}
   cli53_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-cli53:
     needs: matrix-cli53
     if: github.event_name != 'schedule' && needs.matrix-cli53.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/cloud-nuke/**
-      - .github/workflows/cloud-nuke.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/cloud-nuke.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/cloud-nuke/**
       - .github/workflows/cloud-nuke.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   cloud-nuke_VERSION: ${{ inputs.package_version_override }}
   cloud-nuke_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-cloud-nuke:
     needs: matrix-cloud-nuke
     if: github.event_name != 'schedule' && needs.matrix-cloud-nuke.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/cloudflared/**
-      - .github/workflows/cloudflared.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/cloudflared.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/cloudflared/**
       - .github/workflows/cloudflared.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   cloudflared_VERSION: ${{ inputs.package_version_override }}
   cloudflared_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-cloudflared:
     needs: matrix-cloudflared
     if: github.event_name != 'schedule' && needs.matrix-cloudflared.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/codefresh/**
-      - .github/workflows/codefresh.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/codefresh.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/codefresh/**
       - .github/workflows/codefresh.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   codefresh_VERSION: ${{ inputs.package_version_override }}
   codefresh_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-codefresh:
     needs: matrix-codefresh
     if: github.event_name != 'schedule' && needs.matrix-codefresh.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/conftest/**
-      - .github/workflows/conftest.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/conftest.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/conftest/**
       - .github/workflows/conftest.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   conftest_VERSION: ${{ inputs.package_version_override }}
   conftest_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-conftest:
     needs: matrix-conftest
     if: github.event_name != 'schedule' && needs.matrix-conftest.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/consul/**
-      - .github/workflows/consul.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/consul.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/consul/**
       - .github/workflows/consul.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   consul_VERSION: ${{ inputs.package_version_override }}
   consul_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-consul:
     needs: matrix-consul
     if: github.event_name != 'schedule' && needs.matrix-consul.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/ctop/**
-      - .github/workflows/ctop.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/ctop.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/ctop/**
       - .github/workflows/ctop.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   ctop_VERSION: ${{ inputs.package_version_override }}
   ctop_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-ctop:
     needs: matrix-ctop
     if: github.event_name != 'schedule' && needs.matrix-ctop.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/direnv/**
-      - .github/workflows/direnv.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/direnv.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/direnv/**
       - .github/workflows/direnv.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   direnv_VERSION: ${{ inputs.package_version_override }}
   direnv_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-direnv:
     needs: matrix-direnv
     if: github.event_name != 'schedule' && needs.matrix-direnv.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/doctl/**
-      - .github/workflows/doctl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/doctl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/doctl/**
       - .github/workflows/doctl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   doctl_VERSION: ${{ inputs.package_version_override }}
   doctl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-doctl:
     needs: matrix-doctl
     if: github.event_name != 'schedule' && needs.matrix-doctl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/ec2-instance-selector.yml
+++ b/.github/workflows/ec2-instance-selector.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/ec2-instance-selector.yml
+++ b/.github/workflows/ec2-instance-selector.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/ec2-instance-selector/**
-      - .github/workflows/ec2-instance-selector.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/ec2-instance-selector.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/ec2-instance-selector/**
       - .github/workflows/ec2-instance-selector.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   ec2-instance-selector_VERSION: ${{ inputs.package_version_override }}
   ec2-instance-selector_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-ec2-instance-selector:
     needs: matrix-ec2-instance-selector
     if: github.event_name != 'schedule' && needs.matrix-ec2-instance-selector.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ecspresso.yml
+++ b/.github/workflows/ecspresso.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/ecspresso/**
-      - .github/workflows/ecspresso.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/ecspresso.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/ecspresso/**
       - .github/workflows/ecspresso.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   ecspresso_VERSION: ${{ inputs.package_version_override }}
   ecspresso_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-ecspresso:
     needs: matrix-ecspresso
     if: github.event_name != 'schedule' && needs.matrix-ecspresso.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ecspresso.yml
+++ b/.github/workflows/ecspresso.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/emailcli/**
-      - .github/workflows/emailcli.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/emailcli.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/emailcli/**
       - .github/workflows/emailcli.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   emailcli_VERSION: ${{ inputs.package_version_override }}
   emailcli_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-emailcli:
     needs: matrix-emailcli
     if: github.event_name != 'schedule' && needs.matrix-emailcli.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/envcli.yml
+++ b/.github/workflows/envcli.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/envcli/**
-      - .github/workflows/envcli.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/envcli.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/envcli/**
       - .github/workflows/envcli.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   envcli_VERSION: ${{ inputs.package_version_override }}
   envcli_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-envcli:
     needs: matrix-envcli
     if: github.event_name != 'schedule' && needs.matrix-envcli.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/envcli.yml
+++ b/.github/workflows/envcli.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/fetch/**
-      - .github/workflows/fetch.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/fetch.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/fetch/**
       - .github/workflows/fetch.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   fetch_VERSION: ${{ inputs.package_version_override }}
   fetch_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-fetch:
     needs: matrix-fetch
     if: github.event_name != 'schedule' && needs.matrix-fetch.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/figurine/**
-      - .github/workflows/figurine.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/figurine.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/figurine/**
       - .github/workflows/figurine.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   figurine_VERSION: ${{ inputs.package_version_override }}
   figurine_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-figurine:
     needs: matrix-figurine
     if: github.event_name != 'schedule' && needs.matrix-figurine.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/fzf/**
-      - .github/workflows/fzf.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/fzf.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/fzf/**
       - .github/workflows/fzf.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   fzf_VERSION: ${{ inputs.package_version_override }}
   fzf_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-fzf:
     needs: matrix-fzf
     if: github.event_name != 'schedule' && needs.matrix-fzf.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/gh/**
-      - .github/workflows/gh.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/gh.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/gh/**
       - .github/workflows/gh.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   gh_VERSION: ${{ inputs.package_version_override }}
   gh_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-gh:
     needs: matrix-gh
     if: github.event_name != 'schedule' && needs.matrix-gh.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/ghr/**
-      - .github/workflows/ghr.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/ghr.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/ghr/**
       - .github/workflows/ghr.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   ghr_VERSION: ${{ inputs.package_version_override }}
   ghr_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-ghr:
     needs: matrix-ghr
     if: github.event_name != 'schedule' && needs.matrix-ghr.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/github-commenter/**
-      - .github/workflows/github-commenter.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/github-commenter.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/github-commenter/**
       - .github/workflows/github-commenter.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   github-commenter_VERSION: ${{ inputs.package_version_override }}
   github-commenter_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-github-commenter:
     needs: matrix-github-commenter
     if: github.event_name != 'schedule' && needs.matrix-github-commenter.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/github-release/**
-      - .github/workflows/github-release.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/github-release.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/github-release/**
       - .github/workflows/github-release.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   github-release_VERSION: ${{ inputs.package_version_override }}
   github-release_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-github-release:
     needs: matrix-github-release
     if: github.event_name != 'schedule' && needs.matrix-github-release.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/github-status-updater/**
-      - .github/workflows/github-status-updater.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/github-status-updater.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/github-status-updater/**
       - .github/workflows/github-status-updater.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   github-status-updater_VERSION: ${{ inputs.package_version_override }}
   github-status-updater_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-github-status-updater:
     needs: matrix-github-status-updater
     if: github.event_name != 'schedule' && needs.matrix-github-status-updater.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/gitleaks/**
-      - .github/workflows/gitleaks.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/gitleaks.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/gitleaks/**
       - .github/workflows/gitleaks.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   gitleaks_VERSION: ${{ inputs.package_version_override }}
   gitleaks_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-gitleaks:
     needs: matrix-gitleaks
     if: github.event_name != 'schedule' && needs.matrix-gitleaks.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/go-jsonnet.yml
+++ b/.github/workflows/go-jsonnet.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/go-jsonnet/**
-      - .github/workflows/go-jsonnet.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/go-jsonnet.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/go-jsonnet/**
       - .github/workflows/go-jsonnet.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   go-jsonnet_VERSION: ${{ inputs.package_version_override }}
   go-jsonnet_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-go-jsonnet:
     needs: matrix-go-jsonnet
     if: github.event_name != 'schedule' && needs.matrix-go-jsonnet.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/go-jsonnet.yml
+++ b/.github/workflows/go-jsonnet.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/gomplate/**
-      - .github/workflows/gomplate.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/gomplate.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/gomplate/**
       - .github/workflows/gomplate.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   gomplate_VERSION: ${{ inputs.package_version_override }}
   gomplate_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-gomplate:
     needs: matrix-gomplate
     if: github.event_name != 'schedule' && needs.matrix-gomplate.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/gonsul/**
-      - .github/workflows/gonsul.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/gonsul.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/gonsul/**
       - .github/workflows/gonsul.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   gonsul_VERSION: ${{ inputs.package_version_override }}
   gonsul_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-gonsul:
     needs: matrix-gonsul
     if: github.event_name != 'schedule' && needs.matrix-gonsul.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/goofys/**
-      - .github/workflows/goofys.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/goofys.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/goofys/**
       - .github/workflows/goofys.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   goofys_VERSION: ${{ inputs.package_version_override }}
   goofys_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-goofys:
     needs: matrix-goofys
     if: github.event_name != 'schedule' && needs.matrix-goofys.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/gosu/**
-      - .github/workflows/gosu.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/gosu.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/gosu/**
       - .github/workflows/gosu.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   gosu_VERSION: ${{ inputs.package_version_override }}
   gosu_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-gosu:
     needs: matrix-gosu
     if: github.event_name != 'schedule' && needs.matrix-gosu.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/gotop/**
-      - .github/workflows/gotop.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/gotop.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/gotop/**
       - .github/workflows/gotop.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   gotop_VERSION: ${{ inputs.package_version_override }}
   gotop_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-gotop:
     needs: matrix-gotop
     if: github.event_name != 'schedule' && needs.matrix-gotop.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/grpcurl.yml
+++ b/.github/workflows/grpcurl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/grpcurl/**
-      - .github/workflows/grpcurl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/grpcurl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/grpcurl/**
       - .github/workflows/grpcurl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   grpcurl_VERSION: ${{ inputs.package_version_override }}
   grpcurl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-grpcurl:
     needs: matrix-grpcurl
     if: github.event_name != 'schedule' && needs.matrix-grpcurl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/grpcurl.yml
+++ b/.github/workflows/grpcurl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/hcledit.yml
+++ b/.github/workflows/hcledit.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/hcledit/**
-      - .github/workflows/hcledit.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/hcledit.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/hcledit/**
       - .github/workflows/hcledit.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   hcledit_VERSION: ${{ inputs.package_version_override }}
   hcledit_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-hcledit:
     needs: matrix-hcledit
     if: github.event_name != 'schedule' && needs.matrix-hcledit.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/hcledit.yml
+++ b/.github/workflows/hcledit.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/helm/**
-      - .github/workflows/helm.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/helm.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/helm/**
       - .github/workflows/helm.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   helm_VERSION: ${{ inputs.package_version_override }}
   helm_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-helm:
     needs: matrix-helm
     if: github.event_name != 'schedule' && needs.matrix-helm.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/helm2/**
-      - .github/workflows/helm2.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/helm2.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/helm2/**
       - .github/workflows/helm2.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   helm2_VERSION: ${{ inputs.package_version_override }}
   helm2_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-helm2:
     needs: matrix-helm2
     if: github.event_name != 'schedule' && needs.matrix-helm2.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/helm3/**
-      - .github/workflows/helm3.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/helm3.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/helm3/**
       - .github/workflows/helm3.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   helm3_VERSION: ${{ inputs.package_version_override }}
   helm3_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-helm3:
     needs: matrix-helm3
     if: github.event_name != 'schedule' && needs.matrix-helm3.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/helmfile/**
-      - .github/workflows/helmfile.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/helmfile.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/helmfile/**
       - .github/workflows/helmfile.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   helmfile_VERSION: ${{ inputs.package_version_override }}
   helmfile_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-helmfile:
     needs: matrix-helmfile
     if: github.event_name != 'schedule' && needs.matrix-helmfile.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/htmltest/**
-      - .github/workflows/htmltest.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/htmltest.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/htmltest/**
       - .github/workflows/htmltest.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   htmltest_VERSION: ${{ inputs.package_version_override }}
   htmltest_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-htmltest:
     needs: matrix-htmltest
     if: github.event_name != 'schedule' && needs.matrix-htmltest.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/hugo/**
-      - .github/workflows/hugo.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/hugo.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/hugo/**
       - .github/workflows/hugo.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   hugo_VERSION: ${{ inputs.package_version_override }}
   hugo_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-hugo:
     needs: matrix-hugo
     if: github.event_name != 'schedule' && needs.matrix-hugo.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/infracost/**
-      - .github/workflows/infracost.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/infracost.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/infracost/**
       - .github/workflows/infracost.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   infracost_VERSION: ${{ inputs.package_version_override }}
   infracost_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-infracost:
     needs: matrix-infracost
     if: github.event_name != 'schedule' && needs.matrix-infracost.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/jp/**
-      - .github/workflows/jp.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/jp.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/jp/**
       - .github/workflows/jp.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   jp_VERSION: ${{ inputs.package_version_override }}
   jp_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-jp:
     needs: matrix-jp
     if: github.event_name != 'schedule' && needs.matrix-jp.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/json2hcl/**
-      - .github/workflows/json2hcl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/json2hcl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/json2hcl/**
       - .github/workflows/json2hcl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   json2hcl_VERSION: ${{ inputs.package_version_override }}
   json2hcl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-json2hcl:
     needs: matrix-json2hcl
     if: github.event_name != 'schedule' && needs.matrix-json2hcl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/jx/**
-      - .github/workflows/jx.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/jx.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/jx/**
       - .github/workflows/jx.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   jx_VERSION: ${{ inputs.package_version_override }}
   jx_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-jx:
     needs: matrix-jx
     if: github.event_name != 'schedule' && needs.matrix-jx.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/k3d/**
-      - .github/workflows/k3d.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/k3d.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/k3d/**
       - .github/workflows/k3d.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   k3d_VERSION: ${{ inputs.package_version_override }}
   k3d_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-k3d:
     needs: matrix-k3d
     if: github.event_name != 'schedule' && needs.matrix-k3d.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/k6/**
-      - .github/workflows/k6.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/k6.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/k6/**
       - .github/workflows/k6.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   k6_VERSION: ${{ inputs.package_version_override }}
   k6_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-k6:
     needs: matrix-k6
     if: github.event_name != 'schedule' && needs.matrix-k6.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/k9s/**
-      - .github/workflows/k9s.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/k9s.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/k9s/**
       - .github/workflows/k9s.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   k9s_VERSION: ${{ inputs.package_version_override }}
   k9s_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-k9s:
     needs: matrix-k9s
     if: github.event_name != 'schedule' && needs.matrix-k9s.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/katafygio/**
-      - .github/workflows/katafygio.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/katafygio.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/katafygio/**
       - .github/workflows/katafygio.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   katafygio_VERSION: ${{ inputs.package_version_override }}
   katafygio_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-katafygio:
     needs: matrix-katafygio
     if: github.event_name != 'schedule' && needs.matrix-katafygio.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kfctl/**
-      - .github/workflows/kfctl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kfctl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kfctl/**
       - .github/workflows/kfctl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kfctl_VERSION: ${{ inputs.package_version_override }}
   kfctl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kfctl:
     needs: matrix-kfctl
     if: github.event_name != 'schedule' && needs.matrix-kfctl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kind/**
-      - .github/workflows/kind.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kind.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kind/**
       - .github/workflows/kind.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kind_VERSION: ${{ inputs.package_version_override }}
   kind_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kind:
     needs: matrix-kind
     if: github.event_name != 'schedule' && needs.matrix-kind.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kops/**
-      - .github/workflows/kops.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kops.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kops/**
       - .github/workflows/kops.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kops_VERSION: ${{ inputs.package_version_override }}
   kops_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kops:
     needs: matrix-kops
     if: github.event_name != 'schedule' && needs.matrix-kops.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/krew/**
-      - .github/workflows/krew.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/krew.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/krew/**
       - .github/workflows/krew.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   krew_VERSION: ${{ inputs.package_version_override }}
   krew_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-krew:
     needs: matrix-krew
     if: github.event_name != 'schedule' && needs.matrix-krew.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubecron/**
-      - .github/workflows/kubecron.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubecron.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubecron/**
       - .github/workflows/kubecron.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubecron_VERSION: ${{ inputs.package_version_override }}
   kubecron_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubecron:
     needs: matrix-kubecron
     if: github.event_name != 'schedule' && needs.matrix-kubecron.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.13/**
-      - .github/workflows/kubectl-1.13.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.13.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.13/**
       - .github/workflows/kubectl-1.13.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.13_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.13_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_13:
     needs: matrix-kubectl-1_13
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_13.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.14/**
-      - .github/workflows/kubectl-1.14.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.14.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.14/**
       - .github/workflows/kubectl-1.14.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.14_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.14_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_14:
     needs: matrix-kubectl-1_14
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_14.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.15/**
-      - .github/workflows/kubectl-1.15.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.15.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.15/**
       - .github/workflows/kubectl-1.15.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.15_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.15_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_15:
     needs: matrix-kubectl-1_15
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_15.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.16/**
-      - .github/workflows/kubectl-1.16.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.16.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.16/**
       - .github/workflows/kubectl-1.16.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.16_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.16_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_16:
     needs: matrix-kubectl-1_16
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_16.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.17/**
-      - .github/workflows/kubectl-1.17.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.17.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.17/**
       - .github/workflows/kubectl-1.17.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.17_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.17_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_17:
     needs: matrix-kubectl-1_17
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_17.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.18/**
-      - .github/workflows/kubectl-1.18.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.18.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.18/**
       - .github/workflows/kubectl-1.18.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.18_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.18_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_18:
     needs: matrix-kubectl-1_18
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_18.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.19/**
-      - .github/workflows/kubectl-1.19.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.19.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.19/**
       - .github/workflows/kubectl-1.19.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.19_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.19_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_19:
     needs: matrix-kubectl-1_19
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_19.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.20.yml
+++ b/.github/workflows/kubectl-1.20.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.20/**
-      - .github/workflows/kubectl-1.20.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.20.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.20/**
       - .github/workflows/kubectl-1.20.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.20_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.20_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_20:
     needs: matrix-kubectl-1_20
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_20.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.20.yml
+++ b/.github/workflows/kubectl-1.20.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.21.yml
+++ b/.github/workflows/kubectl-1.21.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.21/**
-      - .github/workflows/kubectl-1.21.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.21.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.21/**
       - .github/workflows/kubectl-1.21.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.21_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.21_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_21:
     needs: matrix-kubectl-1_21
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_21.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.21.yml
+++ b/.github/workflows/kubectl-1.21.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.22.yml
+++ b/.github/workflows/kubectl-1.22.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.22/**
-      - .github/workflows/kubectl-1.22.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.22.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.22/**
       - .github/workflows/kubectl-1.22.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.22_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.22_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_22:
     needs: matrix-kubectl-1_22
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_22.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.22.yml
+++ b/.github/workflows/kubectl-1.22.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.23.yml
+++ b/.github/workflows/kubectl-1.23.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.23/**
-      - .github/workflows/kubectl-1.23.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.23.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.23/**
       - .github/workflows/kubectl-1.23.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.23_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.23_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_23:
     needs: matrix-kubectl-1_23
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_23.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.23.yml
+++ b/.github/workflows/kubectl-1.23.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.24.yml
+++ b/.github/workflows/kubectl-1.24.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.24/**
-      - .github/workflows/kubectl-1.24.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.24.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.24/**
       - .github/workflows/kubectl-1.24.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.24_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.24_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_24:
     needs: matrix-kubectl-1_24
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_24.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.24.yml
+++ b/.github/workflows/kubectl-1.24.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.25.yml
+++ b/.github/workflows/kubectl-1.25.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.25/**
-      - .github/workflows/kubectl-1.25.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.25.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.25/**
       - .github/workflows/kubectl-1.25.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.25_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.25_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_25:
     needs: matrix-kubectl-1_25
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_25.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.25.yml
+++ b/.github/workflows/kubectl-1.25.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.26.yml
+++ b/.github/workflows/kubectl-1.26.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.26/**
-      - .github/workflows/kubectl-1.26.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.26.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.26/**
       - .github/workflows/kubectl-1.26.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.26_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.26_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_26:
     needs: matrix-kubectl-1_26
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_26.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.26.yml
+++ b/.github/workflows/kubectl-1.26.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.27.yml
+++ b/.github/workflows/kubectl-1.27.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.27/**
-      - .github/workflows/kubectl-1.27.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.27.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.27/**
       - .github/workflows/kubectl-1.27.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.27_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.27_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_27:
     needs: matrix-kubectl-1_27
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_27.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.27.yml
+++ b/.github/workflows/kubectl-1.27.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.28.yml
+++ b/.github/workflows/kubectl-1.28.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.28.yml
+++ b/.github/workflows/kubectl-1.28.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.28/**
-      - .github/workflows/kubectl-1.28.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.28.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.28/**
       - .github/workflows/kubectl-1.28.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.28_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.28_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_28:
     needs: matrix-kubectl-1_28
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_28.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.29.yml
+++ b/.github/workflows/kubectl-1.29.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.29/**
-      - .github/workflows/kubectl-1.29.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.29.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.29/**
       - .github/workflows/kubectl-1.29.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.29_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.29_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_29:
     needs: matrix-kubectl-1_29
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_29.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.29.yml
+++ b/.github/workflows/kubectl-1.29.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl-1.30.yml
+++ b/.github/workflows/kubectl-1.30.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl-1.30/**
-      - .github/workflows/kubectl-1.30.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl-1.30.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl-1.30/**
       - .github/workflows/kubectl-1.30.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl-1.30_VERSION: ${{ inputs.package_version_override }}
   kubectl-1.30_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl-1_30:
     needs: matrix-kubectl-1_30
     if: github.event_name != 'schedule' && needs.matrix-kubectl-1_30.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.30.yml
+++ b/.github/workflows/kubectl-1.30.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectl/**
-      - .github/workflows/kubectl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectl/**
       - .github/workflows/kubectl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectl_VERSION: ${{ inputs.package_version_override }}
   kubectl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectl:
     needs: matrix-kubectl
     if: github.event_name != 'schedule' && needs.matrix-kubectl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubectx/**
-      - .github/workflows/kubectx.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubectx.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubectx/**
       - .github/workflows/kubectx.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubectx_VERSION: ${{ inputs.package_version_override }}
   kubectx_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubectx:
     needs: matrix-kubectx
     if: github.event_name != 'schedule' && needs.matrix-kubectx.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubens/**
-      - .github/workflows/kubens.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubens.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubens/**
       - .github/workflows/kubens.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubens_VERSION: ${{ inputs.package_version_override }}
   kubens_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubens:
     needs: matrix-kubens
     if: github.event_name != 'schedule' && needs.matrix-kubens.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/kubeval/**
-      - .github/workflows/kubeval.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/kubeval.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/kubeval/**
       - .github/workflows/kubeval.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   kubeval_VERSION: ${{ inputs.package_version_override }}
   kubeval_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-kubeval:
     needs: matrix-kubeval
     if: github.event_name != 'schedule' && needs.matrix-kubeval.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/lazydocker/**
-      - .github/workflows/lazydocker.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/lazydocker.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/lazydocker/**
       - .github/workflows/lazydocker.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   lazydocker_VERSION: ${{ inputs.package_version_override }}
   lazydocker_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-lazydocker:
     needs: matrix-lazydocker
     if: github.event_name != 'schedule' && needs.matrix-lazydocker.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/lectl/**
-      - .github/workflows/lectl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/lectl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/lectl/**
       - .github/workflows/lectl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   lectl_VERSION: ${{ inputs.package_version_override }}
   lectl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-lectl:
     needs: matrix-lectl
     if: github.event_name != 'schedule' && needs.matrix-lectl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/minikube/**
-      - .github/workflows/minikube.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/minikube.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/minikube/**
       - .github/workflows/minikube.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   minikube_VERSION: ${{ inputs.package_version_override }}
   minikube_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-minikube:
     needs: matrix-minikube
     if: github.event_name != 'schedule' && needs.matrix-minikube.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/misspell/**
-      - .github/workflows/misspell.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/misspell.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/misspell/**
       - .github/workflows/misspell.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   misspell_VERSION: ${{ inputs.package_version_override }}
   misspell_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-misspell:
     needs: matrix-misspell
     if: github.event_name != 'schedule' && needs.matrix-misspell.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/opa/**
-      - .github/workflows/opa.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/opa.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/opa/**
       - .github/workflows/opa.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   opa_VERSION: ${{ inputs.package_version_override }}
   opa_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-opa:
     needs: matrix-opa
     if: github.event_name != 'schedule' && needs.matrix-opa.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/pack/**
-      - .github/workflows/pack.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/pack.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/pack/**
       - .github/workflows/pack.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   pack_VERSION: ${{ inputs.package_version_override }}
   pack_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-pack:
     needs: matrix-pack
     if: github.event_name != 'schedule' && needs.matrix-pack.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/packer/**
-      - .github/workflows/packer.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/packer.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/packer/**
       - .github/workflows/packer.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   packer_VERSION: ${{ inputs.package_version_override }}
   packer_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-packer:
     needs: matrix-packer
     if: github.event_name != 'schedule' && needs.matrix-packer.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/pandoc/**
-      - .github/workflows/pandoc.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/pandoc.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/pandoc/**
       - .github/workflows/pandoc.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   pandoc_VERSION: ${{ inputs.package_version_override }}
   pandoc_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-pandoc:
     needs: matrix-pandoc
     if: github.event_name != 'schedule' && needs.matrix-pandoc.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/pgmetrics/**
-      - .github/workflows/pgmetrics.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/pgmetrics.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/pgmetrics/**
       - .github/workflows/pgmetrics.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   pgmetrics_VERSION: ${{ inputs.package_version_override }}
   pgmetrics_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-pgmetrics:
     needs: matrix-pgmetrics
     if: github.event_name != 'schedule' && needs.matrix-pgmetrics.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/pluto/**
-      - .github/workflows/pluto.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/pluto.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/pluto/**
       - .github/workflows/pluto.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   pluto_VERSION: ${{ inputs.package_version_override }}
   pluto_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-pluto:
     needs: matrix-pluto
     if: github.event_name != 'schedule' && needs.matrix-pluto.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/popeye/**
-      - .github/workflows/popeye.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/popeye.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/popeye/**
       - .github/workflows/popeye.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   popeye_VERSION: ${{ inputs.package_version_override }}
   popeye_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-popeye:
     needs: matrix-popeye
     if: github.event_name != 'schedule' && needs.matrix-popeye.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/promtool/**
-      - .github/workflows/promtool.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/promtool.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/promtool/**
       - .github/workflows/promtool.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   promtool_VERSION: ${{ inputs.package_version_override }}
   promtool_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-promtool:
     needs: matrix-promtool
     if: github.event_name != 'schedule' && needs.matrix-promtool.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/rainbow-text.yml
+++ b/.github/workflows/rainbow-text.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/rainbow-text/**
-      - .github/workflows/rainbow-text.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/rainbow-text.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/rainbow-text/**
       - .github/workflows/rainbow-text.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   rainbow-text_VERSION: ${{ inputs.package_version_override }}
   rainbow-text_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-rainbow-text:
     needs: matrix-rainbow-text
     if: github.event_name != 'schedule' && needs.matrix-rainbow-text.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rainbow-text.yml
+++ b/.github/workflows/rainbow-text.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/rakkess/**
-      - .github/workflows/rakkess.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/rakkess.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/rakkess/**
       - .github/workflows/rakkess.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   rakkess_VERSION: ${{ inputs.package_version_override }}
   rakkess_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-rakkess:
     needs: matrix-rakkess
     if: github.event_name != 'schedule' && needs.matrix-rakkess.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/rancher/**
-      - .github/workflows/rancher.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/rancher.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/rancher/**
       - .github/workflows/rancher.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   rancher_VERSION: ${{ inputs.package_version_override }}
   rancher_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-rancher:
     needs: matrix-rancher
     if: github.event_name != 'schedule' && needs.matrix-rancher.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/rbac-lookup/**
-      - .github/workflows/rbac-lookup.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/rbac-lookup.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/rbac-lookup/**
       - .github/workflows/rbac-lookup.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   rbac-lookup_VERSION: ${{ inputs.package_version_override }}
   rbac-lookup_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-rbac-lookup:
     needs: matrix-rbac-lookup
     if: github.event_name != 'schedule' && needs.matrix-rbac-lookup.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/saml2aws/**
-      - .github/workflows/saml2aws.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/saml2aws.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/saml2aws/**
       - .github/workflows/saml2aws.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   saml2aws_VERSION: ${{ inputs.package_version_override }}
   saml2aws_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-saml2aws:
     needs: matrix-saml2aws
     if: github.event_name != 'schedule' && needs.matrix-saml2aws.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/sentry-cli/**
-      - .github/workflows/sentry-cli.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/sentry-cli.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/sentry-cli/**
       - .github/workflows/sentry-cli.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   sentry-cli_VERSION: ${{ inputs.package_version_override }}
   sentry-cli_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-sentry-cli:
     needs: matrix-sentry-cli
     if: github.event_name != 'schedule' && needs.matrix-sentry-cli.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/shellcheck/**
-      - .github/workflows/shellcheck.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/shellcheck.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/shellcheck/**
       - .github/workflows/shellcheck.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   shellcheck_VERSION: ${{ inputs.package_version_override }}
   shellcheck_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-shellcheck:
     needs: matrix-shellcheck
     if: github.event_name != 'schedule' && needs.matrix-shellcheck.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/shfmt/**
-      - .github/workflows/shfmt.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/shfmt.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/shfmt/**
       - .github/workflows/shfmt.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   shfmt_VERSION: ${{ inputs.package_version_override }}
   shfmt_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-shfmt:
     needs: matrix-shfmt
     if: github.event_name != 'schedule' && needs.matrix-shfmt.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/slack-notifier/**
-      - .github/workflows/slack-notifier.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/slack-notifier.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/slack-notifier/**
       - .github/workflows/slack-notifier.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   slack-notifier_VERSION: ${{ inputs.package_version_override }}
   slack-notifier_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-slack-notifier:
     needs: matrix-slack-notifier
     if: github.event_name != 'schedule' && needs.matrix-slack-notifier.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/sops/**
-      - .github/workflows/sops.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/sops.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/sops/**
       - .github/workflows/sops.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   sops_VERSION: ${{ inputs.package_version_override }}
   sops_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-sops:
     needs: matrix-sops
     if: github.event_name != 'schedule' && needs.matrix-sops.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/spacectl.yml
+++ b/.github/workflows/spacectl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/spacectl/**
-      - .github/workflows/spacectl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/spacectl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/spacectl/**
       - .github/workflows/spacectl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   spacectl_VERSION: ${{ inputs.package_version_override }}
   spacectl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-spacectl:
     needs: matrix-spacectl
     if: github.event_name != 'schedule' && needs.matrix-spacectl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/spacectl.yml
+++ b/.github/workflows/spacectl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/spotctl.yml
+++ b/.github/workflows/spotctl.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/spotctl/**
-      - .github/workflows/spotctl.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/spotctl.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/spotctl/**
       - .github/workflows/spotctl.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   spotctl_VERSION: ${{ inputs.package_version_override }}
   spotctl_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-spotctl:
     needs: matrix-spotctl
     if: github.event_name != 'schedule' && needs.matrix-spotctl.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/spotctl.yml
+++ b/.github/workflows/spotctl.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/sshm.yml
+++ b/.github/workflows/sshm.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/sshm/**
-      - .github/workflows/sshm.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/sshm.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/sshm/**
       - .github/workflows/sshm.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   sshm_VERSION: ${{ inputs.package_version_override }}
   sshm_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-sshm:
     needs: matrix-sshm
     if: github.event_name != 'schedule' && needs.matrix-sshm.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sshm.yml
+++ b/.github/workflows/sshm.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/stern/**
-      - .github/workflows/stern.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/stern.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/stern/**
       - .github/workflows/stern.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   stern_VERSION: ${{ inputs.package_version_override }}
   stern_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-stern:
     needs: matrix-stern
     if: github.event_name != 'schedule' && needs.matrix-stern.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/sudosh/**
-      - .github/workflows/sudosh.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/sudosh.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/sudosh/**
       - .github/workflows/sudosh.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   sudosh_VERSION: ${{ inputs.package_version_override }}
   sudosh_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-sudosh:
     needs: matrix-sudosh
     if: github.event_name != 'schedule' && needs.matrix-sudosh.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/teleport-4.3.yml
+++ b/.github/workflows/teleport-4.3.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/teleport-4.3/**
-      - .github/workflows/teleport-4.3.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/teleport-4.3.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/teleport-4.3/**
       - .github/workflows/teleport-4.3.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   teleport-4.3_VERSION: ${{ inputs.package_version_override }}
   teleport-4.3_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-teleport-4_3:
     needs: matrix-teleport-4_3
     if: github.event_name != 'schedule' && needs.matrix-teleport-4_3.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-4.3.yml
+++ b/.github/workflows/teleport-4.3.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/teleport-4.4.yml
+++ b/.github/workflows/teleport-4.4.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/teleport-4.4/**
-      - .github/workflows/teleport-4.4.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/teleport-4.4.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/teleport-4.4/**
       - .github/workflows/teleport-4.4.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   teleport-4.4_VERSION: ${{ inputs.package_version_override }}
   teleport-4.4_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-teleport-4_4:
     needs: matrix-teleport-4_4
     if: github.event_name != 'schedule' && needs.matrix-teleport-4_4.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-4.4.yml
+++ b/.github/workflows/teleport-4.4.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/teleport-5.0.yml
+++ b/.github/workflows/teleport-5.0.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/teleport-5.0/**
-      - .github/workflows/teleport-5.0.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/teleport-5.0.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/teleport-5.0/**
       - .github/workflows/teleport-5.0.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   teleport-5.0_VERSION: ${{ inputs.package_version_override }}
   teleport-5.0_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-teleport-5_0:
     needs: matrix-teleport-5_0
     if: github.event_name != 'schedule' && needs.matrix-teleport-5_0.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-5.0.yml
+++ b/.github/workflows/teleport-5.0.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/teleport/**
-      - .github/workflows/teleport.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/teleport.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/teleport/**
       - .github/workflows/teleport.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   teleport_VERSION: ${{ inputs.package_version_override }}
   teleport_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-teleport:
     needs: matrix-teleport
     if: github.event_name != 'schedule' && needs.matrix-teleport.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-0.11/**
-      - .github/workflows/terraform-0.11.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-0.11.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-0.11/**
       - .github/workflows/terraform-0.11.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-0.11_VERSION: ${{ inputs.package_version_override }}
   terraform-0.11_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-0_11:
     needs: matrix-terraform-0_11
     if: github.event_name != 'schedule' && needs.matrix-terraform-0_11.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-0.12/**
-      - .github/workflows/terraform-0.12.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-0.12.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-0.12/**
       - .github/workflows/terraform-0.12.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-0.12_VERSION: ${{ inputs.package_version_override }}
   terraform-0.12_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-0_12:
     needs: matrix-terraform-0_12
     if: github.event_name != 'schedule' && needs.matrix-terraform-0_12.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-0.13/**
-      - .github/workflows/terraform-0.13.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-0.13.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-0.13/**
       - .github/workflows/terraform-0.13.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-0.13_VERSION: ${{ inputs.package_version_override }}
   terraform-0.13_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-0_13:
     needs: matrix-terraform-0_13
     if: github.event_name != 'schedule' && needs.matrix-terraform-0_13.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-0.14.yml
+++ b/.github/workflows/terraform-0.14.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-0.14/**
-      - .github/workflows/terraform-0.14.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-0.14.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-0.14/**
       - .github/workflows/terraform-0.14.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-0.14_VERSION: ${{ inputs.package_version_override }}
   terraform-0.14_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-0_14:
     needs: matrix-terraform-0_14
     if: github.event_name != 'schedule' && needs.matrix-terraform-0_14.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.14.yml
+++ b/.github/workflows/terraform-0.14.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-0.15.yml
+++ b/.github/workflows/terraform-0.15.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-0.15/**
-      - .github/workflows/terraform-0.15.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-0.15.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-0.15/**
       - .github/workflows/terraform-0.15.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-0.15_VERSION: ${{ inputs.package_version_override }}
   terraform-0.15_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-0_15:
     needs: matrix-terraform-0_15
     if: github.event_name != 'schedule' && needs.matrix-terraform-0_15.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.15.yml
+++ b/.github/workflows/terraform-0.15.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-1.yml
+++ b/.github/workflows/terraform-1.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-1/**
-      - .github/workflows/terraform-1.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-1.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-1/**
       - .github/workflows/terraform-1.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-1_VERSION: ${{ inputs.package_version_override }}
   terraform-1_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-1:
     needs: matrix-terraform-1
     if: github.event_name != 'schedule' && needs.matrix-terraform-1.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-1.yml
+++ b/.github/workflows/terraform-1.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-config-inspect.yml
+++ b/.github/workflows/terraform-config-inspect.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-config-inspect/**
-      - .github/workflows/terraform-config-inspect.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-config-inspect.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-config-inspect/**
       - .github/workflows/terraform-config-inspect.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-config-inspect_VERSION: ${{ inputs.package_version_override }}
   terraform-config-inspect_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-config-inspect:
     needs: matrix-terraform-config-inspect
     if: github.event_name != 'schedule' && needs.matrix-terraform-config-inspect.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-config-inspect.yml
+++ b/.github/workflows/terraform-config-inspect.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-docs/**
-      - .github/workflows/terraform-docs.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-docs.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-docs/**
       - .github/workflows/terraform-docs.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-docs_VERSION: ${{ inputs.package_version_override }}
   terraform-docs_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-docs:
     needs: matrix-terraform-docs
     if: github.event_name != 'schedule' && needs.matrix-terraform-docs.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-module-versions.yml
+++ b/.github/workflows/terraform-module-versions.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform-module-versions/**
-      - .github/workflows/terraform-module-versions.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform-module-versions.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform-module-versions/**
       - .github/workflows/terraform-module-versions.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform-module-versions_VERSION: ${{ inputs.package_version_override }}
   terraform-module-versions_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform-module-versions:
     needs: matrix-terraform-module-versions
     if: github.event_name != 'schedule' && needs.matrix-terraform-module-versions.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-module-versions.yml
+++ b/.github/workflows/terraform-module-versions.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform/**
-      - .github/workflows/terraform.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform/**
       - .github/workflows/terraform.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform_VERSION: ${{ inputs.package_version_override }}
   terraform_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform:
     needs: matrix-terraform
     if: github.event_name != 'schedule' && needs.matrix-terraform.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform_0.11/**
-      - .github/workflows/terraform_0.11.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform_0.11.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform_0.11/**
       - .github/workflows/terraform_0.11.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform_0.11_VERSION: ${{ inputs.package_version_override }}
   terraform_0.11_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform_0_11:
     needs: matrix-terraform_0_11
     if: github.event_name != 'schedule' && needs.matrix-terraform_0_11.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform_0.12/**
-      - .github/workflows/terraform_0.12.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform_0.12.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform_0.12/**
       - .github/workflows/terraform_0.12.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform_0.12_VERSION: ${{ inputs.package_version_override }}
   terraform_0.12_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform_0_12:
     needs: matrix-terraform_0_12
     if: github.event_name != 'schedule' && needs.matrix-terraform_0_12.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terraform_0.13/**
-      - .github/workflows/terraform_0.13.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terraform_0.13.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terraform_0.13/**
       - .github/workflows/terraform_0.13.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terraform_0.13_VERSION: ${{ inputs.package_version_override }}
   terraform_0.13_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terraform_0_13:
     needs: matrix-terraform_0_13
     if: github.event_name != 'schedule' && needs.matrix-terraform_0_13.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terragrunt/**
-      - .github/workflows/terragrunt.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terragrunt.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terragrunt/**
       - .github/workflows/terragrunt.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terragrunt_VERSION: ${{ inputs.package_version_override }}
   terragrunt_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terragrunt:
     needs: matrix-terragrunt
     if: github.event_name != 'schedule' && needs.matrix-terragrunt.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/terrahelp/**
-      - .github/workflows/terrahelp.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/terrahelp.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/terrahelp/**
       - .github/workflows/terrahelp.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   terrahelp_VERSION: ${{ inputs.package_version_override }}
   terrahelp_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-terrahelp:
     needs: matrix-terrahelp
     if: github.event_name != 'schedule' && needs.matrix-terrahelp.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/tflint/**
-      - .github/workflows/tflint.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/tflint.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/tflint/**
       - .github/workflows/tflint.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   tflint_VERSION: ${{ inputs.package_version_override }}
   tflint_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-tflint:
     needs: matrix-tflint
     if: github.event_name != 'schedule' && needs.matrix-tflint.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/tfschema.yml
+++ b/.github/workflows/tfschema.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/tfschema/**
-      - .github/workflows/tfschema.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/tfschema.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/tfschema/**
       - .github/workflows/tfschema.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   tfschema_VERSION: ${{ inputs.package_version_override }}
   tfschema_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-tfschema:
     needs: matrix-tfschema
     if: github.event_name != 'schedule' && needs.matrix-tfschema.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tfschema.yml
+++ b/.github/workflows/tfschema.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/tfsec/**
-      - .github/workflows/tfsec.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/tfsec.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/tfsec/**
       - .github/workflows/tfsec.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   tfsec_VERSION: ${{ inputs.package_version_override }}
   tfsec_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-tfsec:
     needs: matrix-tfsec
     if: github.event_name != 'schedule' && needs.matrix-tfsec.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/thanos/**
-      - .github/workflows/thanos.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/thanos.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/thanos/**
       - .github/workflows/thanos.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   thanos_VERSION: ${{ inputs.package_version_override }}
   thanos_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-thanos:
     needs: matrix-thanos
     if: github.event_name != 'schedule' && needs.matrix-thanos.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/trivy/**
-      - .github/workflows/trivy.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/trivy.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/trivy/**
       - .github/workflows/trivy.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   trivy_VERSION: ${{ inputs.package_version_override }}
   trivy_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-trivy:
     needs: matrix-trivy
     if: github.event_name != 'schedule' && needs.matrix-trivy.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/variant/**
-      - .github/workflows/variant.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/variant.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/variant/**
       - .github/workflows/variant.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   variant_VERSION: ${{ inputs.package_version_override }}
   variant_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-variant:
     needs: matrix-variant
     if: github.event_name != 'schedule' && needs.matrix-variant.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/variant2/**
-      - .github/workflows/variant2.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/variant2.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/variant2/**
       - .github/workflows/variant2.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   variant2_VERSION: ${{ inputs.package_version_override }}
   variant2_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-variant2:
     needs: matrix-variant2
     if: github.event_name != 'schedule' && needs.matrix-variant2.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/vault/**
-      - .github/workflows/vault.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/vault.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/vault/**
       - .github/workflows/vault.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   vault_VERSION: ${{ inputs.package_version_override }}
   vault_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-vault:
     needs: matrix-vault
     if: github.event_name != 'schedule' && needs.matrix-vault.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/velero.yml
+++ b/.github/workflows/velero.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/velero/**
-      - .github/workflows/velero.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/velero.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/velero/**
       - .github/workflows/velero.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   velero_VERSION: ${{ inputs.package_version_override }}
   velero_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-velero:
     needs: matrix-velero
     if: github.event_name != 'schedule' && needs.matrix-velero.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/velero.yml
+++ b/.github/workflows/velero.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/vendir.yml
+++ b/.github/workflows/vendir.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/vendir.yml
+++ b/.github/workflows/vendir.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/vendir/**
-      - .github/workflows/vendir.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/vendir.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/vendir/**
       - .github/workflows/vendir.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   vendir_VERSION: ${{ inputs.package_version_override }}
   vendir_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-vendir:
     needs: matrix-vendir
     if: github.event_name != 'schedule' && needs.matrix-vendir.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/venona/**
-      - .github/workflows/venona.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/venona.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/venona/**
       - .github/workflows/venona.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   venona_VERSION: ${{ inputs.package_version_override }}
   venona_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-venona:
     needs: matrix-venona
     if: github.event_name != 'schedule' && needs.matrix-venona.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/vert/**
-      - .github/workflows/vert.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/vert.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/vert/**
       - .github/workflows/vert.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   vert_VERSION: ${{ inputs.package_version_override }}
   vert_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-vert:
     needs: matrix-vert
     if: github.event_name != 'schedule' && needs.matrix-vert.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/yajsv.yml
+++ b/.github/workflows/yajsv.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/yajsv/**
-      - .github/workflows/yajsv.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/yajsv.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/yajsv/**
       - .github/workflows/yajsv.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   yajsv_VERSION: ${{ inputs.package_version_override }}
   yajsv_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-yajsv:
     needs: matrix-yajsv
     if: github.event_name != 'schedule' && needs.matrix-yajsv.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/yajsv.yml
+++ b/.github/workflows/yajsv.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -18,11 +18,17 @@ on:
       - rpm/**
       - tasks/**
       - vendor/yq/**
-      - .github/workflows/yq.yml
+      # Do not automatically trigger a build when the workflow file is changed, because we often make mass updates.
+      # If we need to run all the workflows, we can just uncomment the line below and make new workflows.
+      # - .github/workflows/yq.yml
 
 
   pull_request:
     types: [opened, synchronize, reopened]
+    # Ignore pulls on branches that start with "mass-update/"
+    # for when we make changes that do not require a new package build, like updating the action
+    branches-ignore:
+      - 'mass-update/**'
     paths:
       - apk/**
       - deb/**
@@ -31,7 +37,6 @@ on:
       - vendor/yq/**
       - .github/workflows/yq.yml
 
-  #bridgecrew:skip=BC_REPO_GITHUB_ACTION_7:The whole point of the workflow dispatch is to feed in a version
   workflow_dispatch:
     inputs:
       package_version_override:
@@ -46,6 +51,12 @@ on:
 env:
   yq_VERSION: ${{ inputs.package_version_override }}
   yq_RELEASE: ${{ inputs.release_number_override }}
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   # Mergify cannot distinguish between 2 jobs with the same name run from different workflows,
@@ -76,7 +87,7 @@ jobs:
 
 
   # Build for alpine linux
-  # Kept separate because it is old and slightly different than the other package builds
+  # Kept separate because it is old and slightly different from the other package builds
   alpine-yq:
     needs: matrix-yq
     if: github.event_name != 'schedule' && needs.matrix-yq.outputs.apk-enabled != 'false'
@@ -96,10 +107,10 @@ jobs:
       PACKAGER_PUBKEY: ${{github.workspace}}/artifacts/ops@cloudposse.com.rsa.pub
 
     container:
-      image: cloudposse/packages-apkbuild:${{matrix.alpine}}
+      image: ghcr.io/cloudposse/packages-apkbuild:${{matrix.alpine}}
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ github.actor }}
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -118,17 +129,14 @@ jobs:
       - name: "List packages"
         run: 'find ${APK_PACKAGES_PATH} -type f -name \*.apk | xargs --no-run-if-empty ls -l | grep .'
 
-      # Export the artifact filename including path
-      # Path must be relative to workdir for Cloudsmith action to be able to find it
+      # Export the artifact filename including path.
+      # Path must be relative to workdir for Cloudsmith action to be able to find it.
       - name: "Set output path to artifact"
         id: artifact
         shell: bash
         run: |
           artifact=$(find artifacts/${{matrix.alpine}} -type f -name \*.apk)
           echo "path=$artifact" | tee -a $GITHUB_OUTPUT
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
 
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
@@ -145,7 +153,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -199,10 +207,10 @@ jobs:
 
     # Unfortunately, there is no reasonable way to configure the docker image tag based on the package-type
     container:
-      image: cloudposse/packages-${{matrix.package-type}}build:latest
+      image: ghcr.io/cloudposse/packages-${{matrix.package-type}}build:latest
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: "${{ github.actor }}"
+        password: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       # Checkout the packages repo so we can build the packages as a monorepo
@@ -232,9 +240,6 @@ jobs:
           echo "setting output"
           echo "path=$packages" | tee -a $GITHUB_OUTPUT
 
-          echo creating '"pip"' cache directory for Cloudsmith
-          mkdir -p $HOME/.cache/pip && chmod -R 777 $HOME/.cache || echo Ignoring error creating '"pip"' cache directory
-
       # Determine which package organization we should use (e.g. dev or prod)
       - name: "Determine package repo"
         shell: bash
@@ -250,7 +255,7 @@ jobs:
 
       # Publish the artifacts
       - name: "Push artifact to package repository"
-        uses: cloudsmith-io/action@v0.5.4
+        uses: cloudsmith-io/action@v0.6.10
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -25,10 +25,7 @@ on:
 
   pull_request:
     types: [opened, synchronize, reopened]
-    # Ignore pulls on branches that start with "mass-update/"
-    # for when we make changes that do not require a new package build, like updating the action
-    branches-ignore:
-      - 'mass-update/**'
+    # Include '[no ci]' in the commit message to keep the workflow from running on that commit in the PR.
     paths:
       - apk/**
       - deb/**


### PR DESCRIPTION
## what

- Update builder image host from Docker Hub to `ghcr.io` (and use new builder)
- Update Cloudsmith action 0.5.4 -> 0.6.10
- Do not automatically run package builder workflow on push to `main` if nothing has changed but the workflow file
- Do not automatically run package builder workflow on PR if branch name starts with `mass-update/`

## why

- When mass-updating packages, we hit Docker Hub rate limits, but `ghcr.io` is more permissive (and better performing on GitHub-hosted runners).
- Old Cloudsmith action ran in a Docker image, and we occasionally ran into issues with Docker-in-Docker. New action is just a Python executable, which works better, but requires us to pre-install Python, which we did in the new builders with #4762.
- Usually, changes to the workflow file are not relevant to the package itself, but are maintenance issues such as updating the action version. Avoid all the waste and overhead of rebuilding packages when nothing substantive has changed.
- When updating a single package, allow the workflow to run, but provide a mechanism to update all the workflows without triggering runs, to avoid the massive unneeded workflow.

## references

- Supersedes and closes #4724
