### PR TITLE
Switch base image from Alpine to Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,37 @@
-# Install CFSSL from official cfssl.org binaries
-FROM cfssl/cfssl:1.5.0 AS cfssl
+# Need to use version number so that it gets updated here and triggers a build
+# Find the current version of Python at https://www.python.org/downloads/source/
+ARG PYTHON_VERSION=3.11.9
+ARG DEBIAN_CODENAME=bookworm
 
-# Install remaining packages
-FROM alpine:3.16.2
+FROM python:${PYTHON_VERSION}-slim-${DEBIAN_CODENAME}
+
+ENV LC_ALL=C.UTF-8
+ENV PS1="(deb) \w \$ "
+
+RUN apt-get update && \
+    apt-get -y -q install bash ruby ruby-dev rubygems build-essential curl git zip bzip2 jq wget sudo
+# https://github.com/jordansissel/fpm/issues/1663
+RUN gem install --no-document backports -v 3.15.0
+RUN gem install --no-document fpm
+
+ARG GO_INSTALL_VERSION=1.23.2
+ARG TARGETARCH
+
+# Install go
+RUN echo downloading go${GO_INSTALL_VERSION} && \
+    curl -sSL --retry 3 -o golang.tar.gz https://golang.org/dl/go${GO_INSTALL_VERSION}.linux-${TARGETARCH}.tar.gz && \
+    tar xzf golang.tar.gz && \
+    mv go /usr/lib/ && rm golang.tar.gz && \
+    ln -s /usr/lib/go/bin/go /usr/bin/go
+
 ENV INSTALL_PATH=/packages/bin
 ENV PATH=${INSTALL_PATH}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN mkdir -p ${INSTALL_PATH}
-RUN apk add --update --no-cache bash make curl coreutils libc6-compat tar xz jq sudo go
-
-COPY --from=cfssl /go/bin/ ${INSTALL_PATH}/
-
-COPY bin/ /usr/local/bin/
 
 COPY . /packages
 RUN mkdir -p /packages/tmp
 RUN make -C /packages/install/ all
+
 WORKDIR /packages
+ENTRYPOINT ["/bin/bash"]
+CMD ["-l"]

--- a/deb/Dockerfile.stable-slim
+++ b/deb/Dockerfile.stable-slim
@@ -26,3 +26,7 @@ RUN echo downloading go${GO_INSTALL_VERSION} && \
 
 
 WORKDIR /packages
+
+# Our base image is Python, with entrypoint into a Python shell, so we need to override the entrypoint
+ENTRYPOINT ["/bin/bash"]
+CMD ["-l"]

--- a/vendor/cfssl/Makefile
+++ b/vendor/cfssl/Makefile
@@ -6,8 +6,11 @@ export PACKAGE_REPO_NAME = cfssl
 export DOWNLOAD_URL = $(PACKAGE_REPO_URL)/releases/download/v$(PACKAGE_VERSION)/$(PACKAGE_NAME)_$(PACKAGE_VERSION)_$(OS)_$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
-# arm64 not supported
-export PACKAGE_ARCHS_DISABLED = arm64
+# arm64 not supported on MacOS, but OK to install AMD64 version
+ifeq ($(OS),darwin)
+	ARCH = amd64
+endif
+# export PACKAGE_ARCHS_DISABLED = arm64
 
 install:
 	$(call download_binary)

--- a/vendor/cfssljson/Makefile
+++ b/vendor/cfssljson/Makefile
@@ -7,8 +7,11 @@ export PACKAGE_REPO_NAME = cfssl
 export DOWNLOAD_URL = $(PACKAGE_REPO_URL)/releases/download/v$(PACKAGE_VERSION)/$(PACKAGE_NAME)_$(PACKAGE_VERSION)_$(OS)_$(ARCH)
 export APK_BUILD_TEMPLATE ?= APKBUILD.github-binary
 
-# arm64 not supported
-export PACKAGE_ARCHS_DISABLED = arm64
+# arm64 not supported on MacOS, but OK to install AMD64 version
+ifeq ($(OS),darwin)
+	ARCH = amd64
+endif
+# export PACKAGE_ARCHS_DISABLED = arm64
 
 install:
 	$(call download_binary)


### PR DESCRIPTION
## what

- One way we publish packages is via a Docker image with the packages loaded. That has previously been based on Alpine. This PR changes the base to Debian.
- Install `amd64` binaries for CloudFlare commands on Apple Silicon Macs

## why

- Alpine has ongoing compatibility issues and Cloud Posse now prefers to use Debian where possible.
- CloudFlare does not publish native `arm64` binaries for their commands, but the `amd64` ones run on `arm64` Macs due to Mac having emulation built into the OS

