### PR TITLE
Add configuration for Runs-On runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,2 @@
+# See https://runs-on.com/configuration/repo-config/
+_extends: .github


### PR DESCRIPTION
## what

- Add configuration to use Runs-On GitHub Action Runners

## why

- Cheaper than GitHub hosted runners


