### PR TITLE
Move arm64 testing to Run-On

### DIFF
--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/package-template.yml
+++ b/.github/package-template.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/amazon-ecr-credential-helper.yml
+++ b/.github/workflows/amazon-ecr-credential-helper.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/amazon-ecr-credential-helper.yml
+++ b/.github/workflows/amazon-ecr-credential-helper.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/amazon-ecr-credential-helper.yml
+++ b/.github/workflows/amazon-ecr-credential-helper.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/amtool.yml
+++ b/.github/workflows/amtool.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/argocd.yml
+++ b/.github/workflows/argocd.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/assume-role.yml
+++ b/.github/workflows/assume-role.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/atlantis.yml
+++ b/.github/workflows/atlantis.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -181,7 +181,7 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-arm64"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=2cpu-linux-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -181,7 +181,7 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/atmos.yml
+++ b/.github/workflows/atmos.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/awless.yml
+++ b/.github/workflows/awless.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-copilot-cli.yml
+++ b/.github/workflows/aws-copilot-cli.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-copilot-cli.yml
+++ b/.github/workflows/aws-copilot-cli.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/aws-copilot-cli.yml
+++ b/.github/workflows/aws-copilot-cli.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/aws-iam-authenticator.yml
+++ b/.github/workflows/aws-iam-authenticator.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/aws-nuke.yml
+++ b/.github/workflows/aws-nuke.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/aws-vault.yml
+++ b/.github/workflows/aws-vault.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/cfssl.yml
+++ b/.github/workflows/cfssl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/cfssljson.yml
+++ b/.github/workflows/cfssljson.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/chamber.yml
+++ b/.github/workflows/chamber.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cilium-cli.yml
+++ b/.github/workflows/cilium-cli.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cilium-cli.yml
+++ b/.github/workflows/cilium-cli.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/cilium-cli.yml
+++ b/.github/workflows/cilium-cli.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/cli53.yml
+++ b/.github/workflows/cli53.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/cloud-nuke.yml
+++ b/.github/workflows/cloud-nuke.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/cloudflared.yml
+++ b/.github/workflows/cloudflared.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/codefresh.yml
+++ b/.github/workflows/codefresh.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/conftest.yml
+++ b/.github/workflows/conftest.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/consul.yml
+++ b/.github/workflows/consul.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/ctop.yml
+++ b/.github/workflows/ctop.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/direnv.yml
+++ b/.github/workflows/direnv.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/doctl.yml
+++ b/.github/workflows/doctl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ec2-instance-selector.yml
+++ b/.github/workflows/ec2-instance-selector.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ec2-instance-selector.yml
+++ b/.github/workflows/ec2-instance-selector.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/ec2-instance-selector.yml
+++ b/.github/workflows/ec2-instance-selector.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ecspresso.yml
+++ b/.github/workflows/ecspresso.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ecspresso.yml
+++ b/.github/workflows/ecspresso.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/ecspresso.yml
+++ b/.github/workflows/ecspresso.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/emailcli.yml
+++ b/.github/workflows/emailcli.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/envcli.yml
+++ b/.github/workflows/envcli.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/envcli.yml
+++ b/.github/workflows/envcli.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/envcli.yml
+++ b/.github/workflows/envcli.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/figurine.yml
+++ b/.github/workflows/figurine.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/fzf.yml
+++ b/.github/workflows/fzf.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/gh.yml
+++ b/.github/workflows/gh.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/ghr.yml
+++ b/.github/workflows/ghr.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/github-commenter.yml
+++ b/.github/workflows/github-commenter.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/github-status-updater.yml
+++ b/.github/workflows/github-status-updater.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/go-jsonnet.yml
+++ b/.github/workflows/go-jsonnet.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/go-jsonnet.yml
+++ b/.github/workflows/go-jsonnet.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/go-jsonnet.yml
+++ b/.github/workflows/go-jsonnet.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/gomplate.yml
+++ b/.github/workflows/gomplate.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/gonsul.yml
+++ b/.github/workflows/gonsul.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/goofys.yml
+++ b/.github/workflows/goofys.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/gosu.yml
+++ b/.github/workflows/gosu.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/gotop.yml
+++ b/.github/workflows/gotop.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/grpcurl.yml
+++ b/.github/workflows/grpcurl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/grpcurl.yml
+++ b/.github/workflows/grpcurl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/grpcurl.yml
+++ b/.github/workflows/grpcurl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/hcledit.yml
+++ b/.github/workflows/hcledit.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/hcledit.yml
+++ b/.github/workflows/hcledit.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/hcledit.yml
+++ b/.github/workflows/hcledit.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/helm2.yml
+++ b/.github/workflows/helm2.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/helm3.yml
+++ b/.github/workflows/helm3.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/helmfile.yml
+++ b/.github/workflows/helmfile.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/infracost.yml
+++ b/.github/workflows/infracost.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/jp.yml
+++ b/.github/workflows/jp.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/json2hcl.yml
+++ b/.github/workflows/json2hcl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/jx.yml
+++ b/.github/workflows/jx.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/k3d.yml
+++ b/.github/workflows/k3d.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/k6.yml
+++ b/.github/workflows/k6.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/k9s.yml
+++ b/.github/workflows/k9s.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/katafygio.yml
+++ b/.github/workflows/katafygio.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kfctl.yml
+++ b/.github/workflows/kfctl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kops.yml
+++ b/.github/workflows/kops.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/krew.yml
+++ b/.github/workflows/krew.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubecron.yml
+++ b/.github/workflows/kubecron.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.13.yml
+++ b/.github/workflows/kubectl-1.13.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.14.yml
+++ b/.github/workflows/kubectl-1.14.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.15.yml
+++ b/.github/workflows/kubectl-1.15.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.16.yml
+++ b/.github/workflows/kubectl-1.16.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.17.yml
+++ b/.github/workflows/kubectl-1.17.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.18.yml
+++ b/.github/workflows/kubectl-1.18.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.19.yml
+++ b/.github/workflows/kubectl-1.19.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.20.yml
+++ b/.github/workflows/kubectl-1.20.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.20.yml
+++ b/.github/workflows/kubectl-1.20.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.20.yml
+++ b/.github/workflows/kubectl-1.20.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.21.yml
+++ b/.github/workflows/kubectl-1.21.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.21.yml
+++ b/.github/workflows/kubectl-1.21.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.21.yml
+++ b/.github/workflows/kubectl-1.21.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.22.yml
+++ b/.github/workflows/kubectl-1.22.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.22.yml
+++ b/.github/workflows/kubectl-1.22.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.22.yml
+++ b/.github/workflows/kubectl-1.22.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.23.yml
+++ b/.github/workflows/kubectl-1.23.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.23.yml
+++ b/.github/workflows/kubectl-1.23.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.23.yml
+++ b/.github/workflows/kubectl-1.23.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.24.yml
+++ b/.github/workflows/kubectl-1.24.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.24.yml
+++ b/.github/workflows/kubectl-1.24.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.24.yml
+++ b/.github/workflows/kubectl-1.24.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.25.yml
+++ b/.github/workflows/kubectl-1.25.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.25.yml
+++ b/.github/workflows/kubectl-1.25.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.25.yml
+++ b/.github/workflows/kubectl-1.25.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.26.yml
+++ b/.github/workflows/kubectl-1.26.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.26.yml
+++ b/.github/workflows/kubectl-1.26.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.26.yml
+++ b/.github/workflows/kubectl-1.26.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.27.yml
+++ b/.github/workflows/kubectl-1.27.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.27.yml
+++ b/.github/workflows/kubectl-1.27.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.27.yml
+++ b/.github/workflows/kubectl-1.27.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.28.yml
+++ b/.github/workflows/kubectl-1.28.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.28.yml
+++ b/.github/workflows/kubectl-1.28.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.28.yml
+++ b/.github/workflows/kubectl-1.28.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.29.yml
+++ b/.github/workflows/kubectl-1.29.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.29.yml
+++ b/.github/workflows/kubectl-1.29.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.29.yml
+++ b/.github/workflows/kubectl-1.29.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.30.yml
+++ b/.github/workflows/kubectl-1.30.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.30.yml
+++ b/.github/workflows/kubectl-1.30.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.30.yml
+++ b/.github/workflows/kubectl-1.30.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.31.yml
+++ b/.github/workflows/kubectl-1.31.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.31.yml
+++ b/.github/workflows/kubectl-1.31.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.31.yml
+++ b/.github/workflows/kubectl-1.31.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.32.yml
+++ b/.github/workflows/kubectl-1.32.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl-1.32.yml
+++ b/.github/workflows/kubectl-1.32.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl-1.32.yml
+++ b/.github/workflows/kubectl-1.32.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectl.yml
+++ b/.github/workflows/kubectl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubectx.yml
+++ b/.github/workflows/kubectx.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubens.yml
+++ b/.github/workflows/kubens.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/kubeval.yml
+++ b/.github/workflows/kubeval.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/lazydocker.yml
+++ b/.github/workflows/lazydocker.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/lectl.yml
+++ b/.github/workflows/lectl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/opa.yml
+++ b/.github/workflows/opa.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/pgmetrics.yml
+++ b/.github/workflows/pgmetrics.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/pluto.yml
+++ b/.github/workflows/pluto.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/popeye.yml
+++ b/.github/workflows/popeye.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/promtool.yml
+++ b/.github/workflows/promtool.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rainbow-text.yml
+++ b/.github/workflows/rainbow-text.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rainbow-text.yml
+++ b/.github/workflows/rainbow-text.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/rainbow-text.yml
+++ b/.github/workflows/rainbow-text.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/rakkess.yml
+++ b/.github/workflows/rakkess.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/rancher.yml
+++ b/.github/workflows/rancher.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/rbac-lookup.yml
+++ b/.github/workflows/rbac-lookup.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/saml2aws.yml
+++ b/.github/workflows/saml2aws.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/sentry-cli.yml
+++ b/.github/workflows/sentry-cli.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/shfmt.yml
+++ b/.github/workflows/shfmt.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/slack-notifier.yml
+++ b/.github/workflows/slack-notifier.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/sops.yml
+++ b/.github/workflows/sops.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/spacectl.yml
+++ b/.github/workflows/spacectl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/spacectl.yml
+++ b/.github/workflows/spacectl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/spacectl.yml
+++ b/.github/workflows/spacectl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/spotctl.yml
+++ b/.github/workflows/spotctl.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/spotctl.yml
+++ b/.github/workflows/spotctl.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/spotctl.yml
+++ b/.github/workflows/spotctl.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sshm.yml
+++ b/.github/workflows/sshm.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sshm.yml
+++ b/.github/workflows/sshm.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/sshm.yml
+++ b/.github/workflows/sshm.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/stern.yml
+++ b/.github/workflows/stern.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/sudosh.yml
+++ b/.github/workflows/sudosh.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-4.3.yml
+++ b/.github/workflows/teleport-4.3.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-4.3.yml
+++ b/.github/workflows/teleport-4.3.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/teleport-4.3.yml
+++ b/.github/workflows/teleport-4.3.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-4.4.yml
+++ b/.github/workflows/teleport-4.4.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-4.4.yml
+++ b/.github/workflows/teleport-4.4.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/teleport-4.4.yml
+++ b/.github/workflows/teleport-4.4.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-5.0.yml
+++ b/.github/workflows/teleport-5.0.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport-5.0.yml
+++ b/.github/workflows/teleport-5.0.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/teleport-5.0.yml
+++ b/.github/workflows/teleport-5.0.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/teleport.yml
+++ b/.github/workflows/teleport.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-0.11.yml
+++ b/.github/workflows/terraform-0.11.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-0.12.yml
+++ b/.github/workflows/terraform-0.12.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-0.13.yml
+++ b/.github/workflows/terraform-0.13.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.14.yml
+++ b/.github/workflows/terraform-0.14.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.14.yml
+++ b/.github/workflows/terraform-0.14.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-0.14.yml
+++ b/.github/workflows/terraform-0.14.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.15.yml
+++ b/.github/workflows/terraform-0.15.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-0.15.yml
+++ b/.github/workflows/terraform-0.15.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-0.15.yml
+++ b/.github/workflows/terraform-0.15.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-1.yml
+++ b/.github/workflows/terraform-1.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-1.yml
+++ b/.github/workflows/terraform-1.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-1.yml
+++ b/.github/workflows/terraform-1.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-config-inspect.yml
+++ b/.github/workflows/terraform-config-inspect.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-config-inspect.yml
+++ b/.github/workflows/terraform-config-inspect.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-config-inspect.yml
+++ b/.github/workflows/terraform-config-inspect.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-module-versions.yml
+++ b/.github/workflows/terraform-module-versions.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform-module-versions.yml
+++ b/.github/workflows/terraform-module-versions.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform-module-versions.yml
+++ b/.github/workflows/terraform-module-versions.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform_0.11.yml
+++ b/.github/workflows/terraform_0.11.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform_0.12.yml
+++ b/.github/workflows/terraform_0.12.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terraform_0.13.yml
+++ b/.github/workflows/terraform_0.13.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terragrunt.yml
+++ b/.github/workflows/terragrunt.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/terrahelp.yml
+++ b/.github/workflows/terrahelp.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tfschema.yml
+++ b/.github/workflows/tfschema.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tfschema.yml
+++ b/.github/workflows/tfschema.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/tfschema.yml
+++ b/.github/workflows/tfschema.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/thanos.yml
+++ b/.github/workflows/thanos.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/variant.yml
+++ b/.github/workflows/variant.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/variant2.yml
+++ b/.github/workflows/variant2.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/vault.yml
+++ b/.github/workflows/vault.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/velero.yml
+++ b/.github/workflows/velero.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/velero.yml
+++ b/.github/workflows/velero.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/velero.yml
+++ b/.github/workflows/velero.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/vendir.yml
+++ b/.github/workflows/vendir.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/vendir.yml
+++ b/.github/workflows/vendir.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/vendir.yml
+++ b/.github/workflows/vendir.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/venona.yml
+++ b/.github/workflows/venona.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/vert.yml
+++ b/.github/workflows/vert.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/yajsv.yml
+++ b/.github/workflows/yajsv.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/yajsv.yml
+++ b/.github/workflows/yajsv.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/yajsv.yml
+++ b/.github/workflows/yajsv.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -151,6 +151,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'
@@ -257,7 +262,7 @@ jobs:
           # This is a hack. We need to hack the action by setting up a `curl` wrapper
           # that injects the GIT_TOKEN into API requests so our rate limit is high enough
           # that we do not have half the packages timing out.
-          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -181,13 +181,13 @@ jobs:
         include:
         # Default value for runs-on. Original matrix values will not be overridden, but added ones (like runs-on) can be.
         # See https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        - runs-on: "self-hosted-arm64-large"
+        - runs-on: "runs-on=${{ github.run_id }}/runner=packages-arm64"
         # By including `arch: amd64` here, we override the `runs-on` value when the matrix `arch` is `amd64`.
         # This also forces the matrix to include `arch: amd64` even if it is not in the original matrix.
         # This is why we do not default for amd64 and then override for arm64. (Because it would force arm64 to be included, and some tools are not available for arm64.)
         - arch: amd64
           runs-on: "ubuntu-latest"
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.arch == 'arm64' && format('{0}/tag=pkg-{1}', matrix.runs-on, matrix.package-type) || matrix.runs-on }}
     env:
       # We are in a bit of a bind here because of how GitHub actions work as of 2020-11-19
       # Although the "workspace" is mounted to the container, it is not mounted

--- a/.github/workflows/yq.yml
+++ b/.github/workflows/yq.yml
@@ -253,6 +253,11 @@ jobs:
       # Publish the artifacts
       - name: "Push artifact to package repository"
         uses: cloudsmith-io/action@v0.6.10
+        env:
+          # This is a hack. We need to hack the action by setting up a `curl` wrapper
+          # that injects the GIT_TOKEN into API requests so our rate limit is high enough
+          # that we do not have half the packages timing out.
+          GITHUB_TOKEN: "${{  matrix.arch == 'arm64' && secrets.GITHUB_TOKEN || '' }}"
         with:
           api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
           command: 'push'

--- a/apk/Dockerfile-alpine
+++ b/apk/Dockerfile-alpine
@@ -20,3 +20,10 @@ RUN apk update && \
     apk add --update -U python3 python3-dev py3-pip libffi-dev gcc linux-headers musl-dev openssl-dev
 
 RUN echo "auth       sufficient   pam_shells.so" > /etc/pam.d/chsh
+
+# Add a wrapper script to authenticate curl requests when directed to GitHub API
+COPY bin/curl-auth /usr/local/bin/curl-auth
+RUN real_curl="$(which curl)" && \
+    mv "${real_curl}" "${real_curl}".real && \
+    mv /usr/local/bin/curl-auth "${real_curl}" && \
+    chmod +x "${real_curl}"

--- a/bin/curl-auth
+++ b/bin/curl-auth
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Authenticate with GitHub using a token when calling the API via curl
+# Needed to get past rate limits with Cloudsmith GitHub action
+
+curl_wrapper() {
+  local args=("$@")
+  local url=""
+
+  # Find the URL argument
+  for arg in "${args[@]}"; do
+    if [[ "$arg" =~ ^https?:// ]]; then
+      url="$arg"
+      break
+    fi
+  done
+
+  # Check if URL is for api.github.com and GITHUB_TOKEN is set
+  if [[ -n "$GITHUB_TOKEN" && -n "$url" && "$url" =~ ^https?://api\.github\.com ]]; then
+    exec curl.real -H "Authorization: Bearer $GITHUB_TOKEN" "${args[@]}"
+  else
+    exec curl.real "${args[@]}"
+  fi
+}
+
+curl_wrapper "$@"

--- a/deb/Dockerfile.stable-slim
+++ b/deb/Dockerfile.stable-slim
@@ -27,6 +27,13 @@ RUN echo downloading go${GO_INSTALL_VERSION} && \
 
 WORKDIR /packages
 
+# Add a wrapper script to authenticate curl requests when directed to GitHub API
+COPY bin/curl-auth /usr/local/bin/curl-auth
+RUN real_curl="$(which curl)" && \
+    mv "${real_curl}" "${real_curl}".real && \
+    mv /usr/local/bin/curl-auth "${real_curl}" && \
+    chmod +x "${real_curl}"
+
 # Our base image is Python, with entrypoint into a Python shell, so we need to override the entrypoint
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/rpm/Dockerfile.ubi
+++ b/rpm/Dockerfile.ubi
@@ -24,3 +24,10 @@ RUN gem install --no-document fpm --ignore-dependencies -N
 
 
 WORKDIR /packages
+
+COPY bin/curl-auth /usr/local/bin/curl-auth
+RUN real_curl="$(which curl)" && \
+    mv "${real_curl}" "${real_curl}".real && \
+    mv /usr/local/bin/curl-auth "${real_curl}" && \
+    chmod +x "${real_curl}"
+


### PR DESCRIPTION
## what

- Move testing of `arm64` packages to Runs-On managed runners

## why

- Better performance and reliability
- Cheaper



