### PR TITLE
kubectl-1.24 EOL

### DIFF
--- a/.github/auto-update-template.yml
+++ b/.github/auto-update-template.yml
@@ -23,10 +23,12 @@ jobs:
 %PACKAGE_LIST%
     steps:
       - uses: actions/checkout@v4
-      # Use updated `go` version because some packages are compiled or fetched with `go`
-      - uses: actions/setup-go@v5
+      # Use specific `go` version when packages updates are fetched with `go`
+      - if: matrix.package-name == 'terraform-config-inspect'
+        uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          cache: false
+          go-version-file: 'vendor/${{matrix.package-name}}/go.mod'
 
       - name: Get current package information
         shell: bash

--- a/.github/workflows/auto-update-packages.yml
+++ b/.github/workflows/auto-update-packages.yml
@@ -148,10 +148,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      # Use updated `go` version because some packages are compiled or fetched with `go`
-      - uses: actions/setup-go@v5
+      # Use specific `go` version when packages updates are fetched with `go`
+      - if: matrix.package-name == 'terraform-config-inspect'
+        uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          cache: false
+          go-version-file: 'vendor/${{matrix.package-name}}/go.mod'
 
       - name: Get current package information
         shell: bash

--- a/vendor/kubectl-1.24/Makefile
+++ b/vendor/kubectl-1.24/Makefile
@@ -4,6 +4,13 @@ export PACKAGE_NAME = $(MASTER_PACKAGE_NAME)-$(MAJOR_VERSION)
 export PACKAGE_REPO_NAME = kubernetes
 export INSTALL_DIR = /usr/share/${MASTER_PACKAGE_NAME}/${MAJOR_VERSION}/bin
 
+# This version is technically past end-of-life, so we allow updates to fail,
+# which can happen because the latest version is not among the latest 100 releases,
+# but we keep checking anyway in case there is a security patch.
+# See https://kubernetes.io/releases/patch-releases/#non-active-branch-history
+# and https://endoflife.date/amazon-eks
+export AUTO_UPDATE_ENABLED = softfail
+
 include ../../tasks/Makefile.vendor_includes
 
 # Package details


### PR DESCRIPTION
## what

- Allow updates for `kubectl-1.24` to fail 
- Only install `go` in auto-update when needed

## why

- Kubernetes 1.24 has reached EOL
- Avoid unnecessary work and log messages

